### PR TITLE
refactor(web): move categories outside rest of the facets

### DIFF
--- a/apps/web/components/GenericModal/GenericModal.tsx
+++ b/apps/web/components/GenericModal/GenericModal.tsx
@@ -12,7 +12,7 @@ interface FacetsModalProps {
 export function GenericModal({ open, onOpenChange, title, children, className }: FacetsModalProps) {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className={cn("max-w-[90%] bg-white sm:max-w-[425px] ", className)}>
+      <DialogContent className={cn("max-w-[90%] content-start bg-white sm:max-w-[425px] ", className)}>
         <DialogHeader>
           <DialogTitle>{title}</DialogTitle>
         </DialogHeader>

--- a/apps/web/views/Listing/CategoryFacet.tsx
+++ b/apps/web/views/Listing/CategoryFacet.tsx
@@ -1,0 +1,34 @@
+import { cn } from "utils/cn"
+
+interface CategoryFacetProps {
+  title: string
+  distribution: Record<string, number> | undefined
+  isChecked: (value: string) => boolean
+  onCheckedChange: (checked: boolean, value: string) => void
+}
+
+export function CategoryFacet({ title, distribution, isChecked, onCheckedChange }: CategoryFacetProps) {
+  const distributionsEntries = Object.entries(distribution || {})
+  const hasNoResults = distributionsEntries.length === 0
+
+  function handleClick(value: string) {
+    onCheckedChange(!isChecked(value), value)
+  }
+
+  return (
+    <div className="my-[72px]">
+      <h2 className="mb-9 text-[22px]/[18px] font-semibold capitalize underline">All {title}</h2>
+      {hasNoResults ? (
+        <p className="text-[14px] text-neutral-500">No {title.toLowerCase()} found</p>
+      ) : (
+        <div className="grid gap-9">
+          {distributionsEntries.map(([value], index) => (
+            <button key={index + value} className={cn("flex items-center gap-2 bg-transparent font-normal", isChecked(value) && "underline")} onClick={() => handleClick(value)}>
+              {value}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/web/views/Listing/FacetsContent.tsx
+++ b/apps/web/views/Listing/FacetsContent.tsx
@@ -8,6 +8,7 @@ import type { CategoriesDistribution } from "meilisearch"
 import { parseAsArrayOf, parseAsInteger, parseAsString, useQueryState } from "nuqs"
 import { ChangeEvent } from "react"
 import { Facet } from "./Facet"
+import { CategoryFacet } from "./CategoryFacet"
 
 interface FacetsContentProps {
   facetDistribution: Record<string, CategoriesDistribution> | undefined
@@ -50,6 +51,22 @@ export function FacetsContent({ facetDistribution, className, disabledFacets }: 
 
   return (
     <div className={className}>
+      {!disabledFacets?.includes("category") ? (
+        <CategoryFacet
+          title="categories"
+          distribution={collections}
+          isChecked={(category) => selectedCategories.includes(category)}
+          onCheckedChange={(checked, category) => {
+            console.log({ checked, category })
+            setSelectedCategories((prev) => {
+              console.log({ prev })
+
+              return checked ? [...prev, category] : prev.filter((cat) => cat !== category)
+            })
+            setPage(1)
+          }}
+        />
+      ) : null}
       <div className={"relative mb-6 block overflow-hidden rounded-md"}>
         <div className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3.5">
           <SearchIcon className="size-4 text-neutral-500" />
@@ -67,19 +84,6 @@ export function FacetsContent({ facetDistribution, className, disabledFacets }: 
       </div>
 
       <Accordion collapsible className="w-full" type="single">
-        {!disabledFacets?.includes("category") ? (
-          <Facet
-            id="category"
-            title="Category"
-            distribution={collections}
-            isChecked={(category) => selectedCategories.includes(category)}
-            onCheckedChange={(checked, category) => {
-              setSelectedCategories((prev) => (checked ? [...prev, category] : prev.filter((cat) => cat !== category)))
-              setPage(1)
-            }}
-          />
-        ) : null}
-
         {!disabledFacets?.includes("tags") ? (
           <Facet
             id="tags"


### PR DESCRIPTION
- Move categories away from rest of the facets
- create new ui for categories
- adjust mobile drawer so content displays from the start 