### PR TITLE
refactor(web): fix carousel behaviour

### DIFF
--- a/apps/web/components/Carousel/Carousel.stories.tsx
+++ b/apps/web/components/Carousel/Carousel.stories.tsx
@@ -14,7 +14,7 @@ type Story = StoryObj<typeof Carousel>
 
 export const Default: Story = {
   render: () => (
-    <Carousel opts={{ containScroll: "keepSnaps", dragFree: true }}>
+    <Carousel opts={{ skipSnaps: true }}>
       <CarouselContent className="ml-0 justify-start gap-8">
         {Array.from({ length: 8 }, (product, idx) => (
           <img src="https://picsum.photos/200/300" key={idx} alt="" />

--- a/apps/web/components/Carousel/Carousel.tsx
+++ b/apps/web/components/Carousel/Carousel.tsx
@@ -49,6 +49,7 @@ const Carousel = forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>
       },
       plugins
     )
+
     const [canScrollPrev, setCanScrollPrev] = useState(false)
     const [canScrollNext, setCanScrollNext] = useState(false)
 

--- a/apps/web/views/Homepage/CarouselSection.tsx
+++ b/apps/web/views/Homepage/CarouselSection.tsx
@@ -10,7 +10,7 @@ interface CarouselSectionProps {
 
 export function CarouselSection({ items, title }: CarouselSectionProps) {
   return (
-    <Carousel opts={{ containScroll: "keepSnaps", dragFree: true }}>
+    <Carousel opts={{ skipSnaps: true }}>
       <div className="max-w-container-md mx-auto flex flex-col gap-16 px-4 py-20 md:pb-32 md:pt-24 xl:px-0">
         <div className="flex basis-1/3 justify-between text-left text-5xl font-normal tracking-tighter sm:min-w-[280px] md:text-left md:text-6xl">
           <h2>{title}</h2>

--- a/apps/web/views/Homepage/ProductsWeekSection.tsx
+++ b/apps/web/views/Homepage/ProductsWeekSection.tsx
@@ -18,7 +18,7 @@ export async function ProductsWeekSection() {
           <h2>Products of the week</h2>
         </div>
         <div className="w-full">
-          <Carousel opts={{ containScroll: "keepSnaps", dragFree: true }}>
+          <Carousel opts={{ skipSnaps: true }}>
             <CarouselContent className="ml-0 justify-start gap-8">
               {items.map((product, idx) => (
                 <Link aria-label={`Go to ${product.title}`} key={"newest_" + product.id + idx} href={`/products/${product.handle}`} prefetch={false}>

--- a/apps/web/views/Product/GallerySection.tsx
+++ b/apps/web/views/Product/GallerySection.tsx
@@ -63,7 +63,7 @@ export function GallerySection({ className, images, children }: GallerySectionPr
         </div>
       </Carousel>
 
-      <Carousel setApi={setThumbsApi} opts={{ containScroll: "keepSnaps", dragFree: true }}>
+      <Carousel setApi={setThumbsApi} opts={{ skipSnaps: true }}>
         <CarouselContent className="ml-0 h-[100px] w-full justify-start gap-6">
           {images.map((image, index) => (
             <div

--- a/apps/web/views/Product/SimilarProductsSection.tsx
+++ b/apps/web/views/Product/SimilarProductsSection.tsx
@@ -18,7 +18,7 @@ export async function SimilarProductsSection({ slug, collection }: SimilarProduc
   return (
     <section className="py-40">
       <h2 className="mb-10 text-[26px] font-normal tracking-[-0.78px]">You might also like</h2>
-      <Carousel opts={{ containScroll: "keepSnaps", dragFree: true }}>
+      <Carousel opts={{ skipSnaps: true }}>
         <CarouselContent className="ml-0 justify-start gap-6">
           {items.map((product, idx) => (
             <ProductCard className="w-[150px] overflow-hidden md:min-w-[280px] md:max-w-[280px]" key={"featured_" + product.id + idx} {...product} />


### PR DESCRIPTION
- Fix carousel behaviour
- Don't use `containScroll` together with `dragFree` seems to be breaking behaviour, as soon as `containScroll` is removed functionality works back again, but instead of using `dragFree` which removes snapping completely, we will snap by default and skipSnaps only if user drags vigorously see [here](https://www.embla-carousel.com/api/options/#skipsnaps)