### PR TITLE
refactor(web): disable scroll for the links in the variants section

### DIFF
--- a/apps/web/views/Product/VariantsSection.tsx
+++ b/apps/web/views/Product/VariantsSection.tsx
@@ -22,8 +22,9 @@ export function VariantsSection({ variants, className, handle, combination }: Va
             href={createOptionfulUrl(handle, singleCombination.size, singleCombination.color)}
             key={singleCombination.id}
             prefetch={false}
+            scroll={false}
             className={cn(
-              "relative flex h-[40px] min-w-[80px] cursor-pointer items-center justify-center border border-black bg-white p-1.5 text-[11px] uppercase transition-colors hover:bg-neutral-800 hover:text-white disabled:cursor-not-allowed disabled:hover:text-black",
+              "relative flex h-[40px] min-w-[80px] cursor-pointer items-center justify-center border border-black bg-white p-1.5 text-[11px] uppercase transition-colors hover:bg-neutral-800 hover:text-white",
               { "bg-neutral-800 text-white": singleCombination.id === combination?.id },
               { "stroke-black opacity-80 hover:bg-transparent hover:text-black": !singleCombination.availableForSale }
             )}


### PR DESCRIPTION
I suggest disabling scroll behavior for links in the variants section. Why? Particularly on mobile devices, it can be quite annoying when the page scrolls to the top every time the user changes the product variant. All variants are visible only after scrolling down the page, as we have product thumbnails at the top. I believe it would improve the user experience.

I also removed unnecessary css classes.