### PR TITLE
refactor(web): Detach CLP & PLP

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,10 @@
-
 <a href="https://blazity.com/r/commerce">
 
 ![HERO](https://github.com/Blazity/enterprise-commerce/assets/28964599/1ff1a75d-30ea-41dd-aa9a-b530b2baed51)
 
 </a>
 
-
-[![GitHub Actions Workflow Status][check-workflow-badge]][check-workflow-badge-link] [![GitHub License][github-license-badge]][github-license-badge-link] [![GitHub contributors][github-contributors-badge]][github-contributors-badge-link] [![Discord][discord-badge]][discord-badge-link] [![Blazity][made-by-blazity-badge]][made-by-blazity-badge-link] [![Blazity][made-with-v0-badge]][made-with-v0-link] 
+[![GitHub Actions Workflow Status][check-workflow-badge]][check-workflow-badge-link] [![GitHub License][github-license-badge]][github-license-badge-link] [![GitHub contributors][github-contributors-badge]][github-contributors-badge-link] [![Discord][discord-badge]][discord-badge-link] [![Blazity][made-by-blazity-badge]][made-by-blazity-badge-link] [![Blazity][made-with-v0-badge]][made-with-v0-link]
 
 🚀 Launch your high-performance Shopify storefront in minutes, not weeks, with this Next.js commerce starter. Leverage the power of Vector Search and AI to deliver a superior online shopping experience without the development headaches.
 
@@ -16,11 +14,10 @@ Run this command and let our CLI do the job or [see our documentation for manual
 $ yarn create commerce
 ```
 
-
-[See the live demo](https://blazity.com/r/commerce) or deploy it straight to Vercel: 
+[See the live demo](https://blazity.com/r/commerce) or deploy it straight to Vercel:
 
 [![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2FBlazity%2Fenterprise-commerce%2Ftree%2Fmain%2F&env=FLAGS_SECRET&demo-title=Your%20Commerce&demo-description=AI-FIRST%20NEXT.JS%20STOREFRONT%20FOR%20COMPOSABLE%20COMMERCE&demo-url=https%3A%2F%2Fblazity.com%2Fr%2Fcommerce&demo-image=https%3A%2F%2Fcommerce.blazity.com%2Fopengraph-image.jpg)
-  
+
 ## Features
 
 - Next.js App Router & Turborepo
@@ -32,7 +29,7 @@ $ yarn create commerce
 - [Designed with v0](https://v0.dev/)
 - AI Image captioning
 - Perfect Performance & SEO
-- Extremely strict TypeScript 
+- Extremely strict TypeScript
 - Draft Mode
 - A/B Tests
 - Shadcn UI
@@ -48,8 +45,9 @@ $ yarn create commerce
 - T3 Env - manage your environment variables with ease
 - Patch-package - fix external dependencies without losing your mind
 - Components coupling and cohesion graph - a tool for managing component relationships
+- Category Landing Page detached from Product Listing for fast SEO indexing & better performance
 
-## Architecture 
+## Architecture
 
 In Enterprise Commerce high-level architecture, Meilisearch serves as the primary source for all product data and potentially other types of data in the future. The system is designed to easily integrate AI personalization tools without needing to modify any frontend code. While we are integrated with Shopify by default, we are not tightly bound to it, and you can use any system that works with Meilisearch and can adapt data to our format.
 
@@ -57,17 +55,14 @@ From a structural viewpoint, we use a monorepo (Turborepo) to manage packages, e
 
 <img width="1841" alt="architecture diagram" src="https://github.com/Blazity/enterprise-commerce/assets/28964599/c5d3a0b3-6c3e-47df-9c45-4ecb583f5a64">
 
-
-
 ## Performance
 
-At Blazity, we prioritize speed. Enterprise Commerce is meticulously crafted to deliver top-notch performance for your online store.  
+At Blazity, we prioritize speed. Enterprise Commerce is meticulously crafted to deliver top-notch performance for your online store.
 
-Lighthouse scores offer a valuable comparison tool, but they don’t directly translate to SEO or user experience (UX). 
+Lighthouse scores offer a valuable comparison tool, but they don’t directly translate to SEO or user experience (UX).
 For a true picture, prioritize real user data. Tools like CrUX or Vercel Speed Insights provide user-based performance metrics, ensuring your online store delivers a seamless experience for your customers.
 
 ![performance diagram](https://github.com/Blazity/enterprise-commerce/assets/28964599/8aba9b68-38d6-41c9-81a8-234003e7e1b0)
-
 
 ## 🤝 Contribution
 
@@ -93,15 +88,12 @@ If you're looking for help or simply want to share your thoughts about the proje
 
 This project is licensed under the MIT License. For more information, see the [LICENSE](./LICENSE) file.
 
-
-
 [check-workflow-badge]: https://img.shields.io/github/actions/workflow/status/blazity/enterprise-commerce/check.yml?label=check
 [github-license-badge]: https://img.shields.io/github/license/blazity/enterprise-commerce?link=https%3A%2F%2Fgithub.com%2FBlazity%2Fenterprise-commerce%2Fblob%2Fmain%2FLICENSE
 [github-contributors-badge]: https://img.shields.io/github/contributors/blazity/enterprise-commerce?link=https%3A%2F%2Fgithub.com%2FBlazity%2Fenterprise-commerce%2Fgraphs%2Fcontributors
 [discord-badge]: https://img.shields.io/discord/1111676875782234175?color=7b8dcd&link=https%3A%2F%2Fblazity.com%2Fdiscord
 [made-by-blazity-badge]: https://img.shields.io/badge/made_by-Blazity-blue?color=FF782B&link=https://blazity.com/
 [made-with-v0-badge]: https://img.shields.io/badge/designed_with-v0-red?color=black&link=https://blazity.com/
-
 [check-workflow-badge-link]: https://github.com/Blazity/enterprise-commerce/actions/workflows/check.yml
 [github-license-badge-link]: https://github.com/Blazity/enterprise-commerce/blob/main/LICENSE
 [github-contributors-badge-link]: https://github.com/Blazity/enterprise-commerce/graphs/contributors

--- a/apps/web/app/category/clp/[slug]/[page]/page.tsx
+++ b/apps/web/app/category/clp/[slug]/[page]/page.tsx
@@ -17,22 +17,9 @@ export async function generateMetadata({ params }: CategoryPageProps): Promise<M
 }
 
 export async function generateStaticParams() {
-  const collection = (await storefrontClient.getCollections()) || []
+  const collections = (await storefrontClient.getCollections()) || []
 
-  return collection
-    ?.map((collection) => {
-      return [
-        {
-          slug: collection.handle,
-          page: "2",
-        },
-        {
-          slug: collection.handle,
-          page: "3",
-        },
-      ]
-    })
-    .flat()
+  return collections.map((collection) => Array.from({ length: 3 }, (_, i) => i + 2).map((page) => ({ slug: collection.handle, page: page.toString() }))).flat()
 }
 
 export default async function CategoryPage({ params }: CategoryPageProps) {

--- a/apps/web/app/category/clp/[slug]/page.tsx
+++ b/apps/web/app/category/clp/[slug]/page.tsx
@@ -1,4 +1,3 @@
-import { storefrontClient } from "clients/storefrontClient"
 import type { Metadata } from "next"
 import { CategoryView } from "views/Category/CategoryView"
 
@@ -14,12 +13,6 @@ export async function generateMetadata({ params }: CategoryPageProps): Promise<M
     title: `${params.slug} | Enterprise Commerce`,
     description: "In excepteur elit mollit in.",
   }
-}
-
-export async function generateStaticParams() {
-  const collections = (await storefrontClient.getCollections()) || []
-
-  return collections?.map((collection) => ({ slug: collection.handle }))
 }
 
 export default async function CategoryPage({ params }: CategoryPageProps) {

--- a/apps/web/app/category/clp/[slug]/page.tsx
+++ b/apps/web/app/category/clp/[slug]/page.tsx
@@ -1,0 +1,27 @@
+import { storefrontClient } from "clients/storefrontClient"
+import type { Metadata } from "next"
+import { CategoryView } from "views/Category/CategoryView"
+
+export const revalidate = 3600
+export const dynamic = "force-static"
+
+interface CategoryPageProps {
+  params: { slug: string }
+}
+
+export async function generateMetadata({ params }: CategoryPageProps): Promise<Metadata> {
+  return {
+    title: `${params.slug} | Enterprise Commerce`,
+    description: "In excepteur elit mollit in.",
+  }
+}
+
+export async function generateStaticParams() {
+  const collections = (await storefrontClient.getCollections()) || []
+
+  return collections?.map((collection) => ({ slug: collection.handle }))
+}
+
+export default async function CategoryPage({ params }: CategoryPageProps) {
+  return <CategoryView params={params} />
+}

--- a/apps/web/app/category/page/[page]/[slug]/page.tsx
+++ b/apps/web/app/category/page/[page]/[slug]/page.tsx
@@ -1,0 +1,40 @@
+import { storefrontClient } from "clients/storefrontClient"
+import type { Metadata } from "next"
+import { CategoryView } from "views/Category/CategoryView"
+
+export const revalidate = 3600
+export const dynamic = "force-static"
+
+interface CategoryPageProps {
+  params: { slug: string; page: string }
+}
+
+export async function generateMetadata({ params }: CategoryPageProps): Promise<Metadata> {
+  return {
+    title: `${params.slug} | Enterprise Commerce`,
+    description: "In excepteur elit mollit in.",
+  }
+}
+
+export async function generateStaticParams() {
+  const collection = (await storefrontClient.getCollections()) || []
+
+  return collection
+    ?.map((collection) => {
+      return [
+        {
+          slug: collection.handle,
+          page: "2",
+        },
+        {
+          slug: collection.handle,
+          page: "3",
+        },
+      ]
+    })
+    .flat()
+}
+
+export default async function CategoryPage({ params }: CategoryPageProps) {
+  return <CategoryView searchParams={{ page: params.page }} params={params} />
+}

--- a/apps/web/app/category/plp/[slug]/page.tsx
+++ b/apps/web/app/category/plp/[slug]/page.tsx
@@ -1,0 +1,23 @@
+import type { Metadata } from "next"
+import { SearchParamsType } from "types"
+import { CategoryView } from "views/Category/CategoryView"
+
+export const runtime = "edge"
+
+export const revalidate = 3600
+
+interface ProductListingPageProps {
+  searchParams: SearchParamsType
+  params: { slug: string }
+}
+
+export async function generateMetadata({ params }: ProductListingPageProps): Promise<Metadata> {
+  return {
+    title: `${params.slug} | Enterprise Commerce`,
+    description: "In excepteur elit mollit in.",
+  }
+}
+
+export default async function ProductListingPage({ searchParams, params }: ProductListingPageProps) {
+  return <CategoryView params={params} searchParams={searchParams} />
+}

--- a/apps/web/app/pages/[slug]/page.tsx
+++ b/apps/web/app/pages/[slug]/page.tsx
@@ -2,9 +2,7 @@ import { format } from "date-fns/format"
 import { getAllPages, getPage } from "app/actions/page.actions"
 
 export const revalidate = 3600
-
 export const dynamic = "force-static"
-
 export const dynamicParams = true
 
 export { generateMetadata } from "./metadata"

--- a/apps/web/app/search/page.tsx
+++ b/apps/web/app/search/page.tsx
@@ -1,20 +1,5 @@
-import { PlatformProduct } from "@enterprise-commerce/core/platform/types"
 import type { Metadata } from "next"
-import { unstable_cache } from "next/cache"
-import { createSearchParamsCache, parseAsArrayOf, parseAsInteger, parseAsString } from "nuqs/server"
-import { Suspense } from "react"
-import { meilisearch } from "clients/meilisearch"
-
-import { MEILISEARCH_INDEX } from "constants/index"
-import { FilterBuilder } from "utils/filterBuilder"
-import { composeFilters } from "views/Listing/composeFilters"
-import { FacetsDesktop } from "views/Listing/FacetsDesktop"
-import { FacetsMobile } from "views/Listing/FacetsMobile"
-import { HitsSection } from "views/Listing/HitsSection"
-import { PageSkeleton } from "views/Listing/PageSkeleton"
-import { PaginationSection } from "views/Listing/PaginationSection"
-import { Sorter } from "views/Listing/Sorter"
-import { getDemoProducts, isDemoMode } from "utils/demoUtils"
+import { SearchView } from "views/Search/SearchView"
 
 export const metadata: Metadata = {
   title: "Search | Enterprise Commerce",
@@ -25,81 +10,10 @@ export const runtime = "edge"
 
 export const revalidate = 3600
 
-const searchParamsCache = createSearchParamsCache({
-  q: parseAsString.withDefault(""),
-  page: parseAsInteger.withDefault(1),
-  minPrice: parseAsInteger,
-  maxPrice: parseAsInteger,
-  sortBy: parseAsString.withDefault(""),
-  categories: parseAsArrayOf(parseAsString).withDefault([]),
-  vendors: parseAsArrayOf(parseAsString).withDefault([]),
-  tags: parseAsArrayOf(parseAsString).withDefault([]),
-  colors: parseAsArrayOf(parseAsString).withDefault([]),
-  sizes: parseAsArrayOf(parseAsString).withDefault([]),
-})
-
 interface SearchPageProps {
   searchParams: Record<string, string | string[] | undefined>
 }
 
 export default async function SearchPage({ searchParams }: SearchPageProps) {
-  return (
-    <Suspense fallback={<PageSkeleton />}>
-      <SearchView searchParams={searchParams} />
-    </Suspense>
-  )
+  return <SearchView searchParams={searchParams} />
 }
-
-async function SearchView({ searchParams }: SearchPageProps) {
-  const { q, sortBy, page, ...rest } = searchParamsCache.parse(searchParams)
-
-  const { totalHits, facetDistribution, hits, totalPages } = await searchProducts(q, sortBy, page, composeFilters(new FilterBuilder(), rest).build())
-
-  return (
-    <div className="max-w-container-md mx-auto flex min-h-screen w-full flex-col gap-12 px-4 py-12 md:flex-row md:gap-24 md:py-24 xl:px-0 ">
-      <FacetsDesktop className="hidden min-w-[250px] max-w-[250px] md:mt-16 lg:block" facetDistribution={facetDistribution} />
-      <div className="flex w-full flex-col">
-        <div className="mb-6 flex w-full flex-wrap items-center justify-between">
-          <div className="flex w-full flex-col gap-2 pb-8">
-            <div className="flex items-center justify-between">
-              <h1 className="text-[32px] font-semibold text-black">
-                Products <span className="hidden text-[21px] font-normal text-slate-700 md:inline-flex">(All {totalHits})</span>
-              </h1>
-              <FacetsMobile facetDistribution={facetDistribution} className="block lg:hidden" />
-            </div>
-            <Sorter className="ml-auto" />
-          </div>
-
-          <HitsSection hits={hits} />
-          <PaginationSection queryParams={searchParams} totalPages={totalPages} />
-        </div>
-      </div>
-    </div>
-  )
-}
-
-const searchProducts = unstable_cache(
-  async (query: string, sortBy: string, page: number, filter: string) => {
-    if (isDemoMode()) return getDemoProducts()
-
-    const index = await meilisearch?.getIndex<PlatformProduct>(MEILISEARCH_INDEX)
-
-    const results = await index?.search(query, {
-      sort: sortBy ? [sortBy] : undefined,
-      hitsPerPage: 24,
-      facets: ["collections.title", "tags", "vendor", "variants.availableForSale", "flatOptions.Size", "flatOptions.Color", "minPrice"],
-      filter,
-      page,
-      attributesToRetrieve: ["id", "handle", "title", "priceRange", "featuredImage", "minPrice", "variants", "images"],
-    })
-
-    const hits = results?.hits || []
-    const totalPages = results?.totalPages || 0
-    const facetDistribution = results?.facetDistribution || {}
-    const totalHits = results.totalHits
-
-    return { hits, totalPages, facetDistribution, totalHits }
-  },
-  ["products-search"],
-  { revalidate: 3600 }
-)

--- a/apps/web/app/search/page.tsx
+++ b/apps/web/app/search/page.tsx
@@ -1,4 +1,7 @@
 import type { Metadata } from "next"
+import { Suspense } from "react"
+import type { SearchParamsType } from "types"
+import { PageSkeleton } from "views/Category/PageSkeleton"
 import { SearchView } from "views/Search/SearchView"
 
 export const metadata: Metadata = {
@@ -11,9 +14,13 @@ export const runtime = "edge"
 export const revalidate = 3600
 
 interface SearchPageProps {
-  searchParams: Record<string, string | string[] | undefined>
+  searchParams: SearchParamsType
 }
 
 export default async function SearchPage({ searchParams }: SearchPageProps) {
-  return <SearchView searchParams={searchParams} />
+  return (
+    <Suspense fallback={<PageSkeleton />}>
+      <SearchView searchParams={searchParams} />
+    </Suspense>
+  )
 }

--- a/apps/web/constants/index.ts
+++ b/apps/web/constants/index.ts
@@ -12,3 +12,5 @@ export const TAGS = {
 export const BUCKETS = {
   HOME: ["a", "b"],
 } as const
+
+export const facetParams = ["q", "minPrice", "maxPrice", "sortBy", "categories", "vendors", "tags", "colors", "sizes"]

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -96,7 +96,7 @@ function handleCLPMiddleware(request: NextRequest) {
   const page = request.nextUrl.searchParams.get("page")
 
   if (page) {
-    url.pathname = `category/page/${page}/${request.nextUrl.pathname.split("/")[2]}`
+    url.pathname = `category/clp/${request.nextUrl.pathname.split("/")[2]}/${page}`
     url.searchParams.delete("page")
 
     return NextResponse.rewrite(url)
@@ -123,7 +123,7 @@ export const config = {
 
 function isCLP(request: NextRequest): boolean {
   const isCategory = request.nextUrl.pathname.startsWith("/category/")
-  const isInternalRoute = request.nextUrl.pathname.startsWith("/category/clp/") || request.nextUrl.pathname.startsWith("/category/page/")
+  const isInternalRoute = request.nextUrl.pathname.startsWith("/category/clp/")
   const isFaceted = facetParams.some((param) => request.nextUrl.searchParams.has(param))
 
   return isCategory && !isFaceted && !isInternalRoute

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -1,7 +1,7 @@
 import { ScalableBloomFilter } from "bloom-filters"
 import { NextRequest, NextResponse } from "next/server"
 import { getBucket } from "utils/abTesting"
-import { BUCKETS } from "constants/index"
+import { BUCKETS, facetParams } from "constants/index"
 import GeneratedBloomFilter from "./redirects/bloom-filter.json"
 
 type RedirectEntry = {
@@ -31,12 +31,24 @@ export async function middleware(request: NextRequest) {
   const homeAwarePathname = pathname === "/" ? "/home" : pathname
 
   if (BLOOM_FILTER.has(homeAwarePathname)) {
-    return handleRedirectsMiddleware(request)
+    const response = await handleRedirectsMiddleware(request)
+
+    if (response) {
+      return response
+    }
   }
 
   const route = ROUTES[pathname]
   if (route) {
     return handleAbTestingMiddleware(request, route)
+  }
+
+  if (isCLP(request)) {
+    return handleCLPMiddleware(request)
+  }
+
+  if (isPLP(request)) {
+    return handlePLPMiddleware(request)
   }
 
   return NextResponse.next()
@@ -79,8 +91,48 @@ function handleAbTestingMiddleware(request: NextRequest, route: Route) {
   return res
 }
 
+function handleCLPMiddleware(request: NextRequest) {
+  const url = request.nextUrl.clone()
+  const page = request.nextUrl.searchParams.get("page")
+
+  if (page) {
+    url.pathname = `category/page/${page}/${request.nextUrl.pathname.split("/")[2]}`
+    url.searchParams.delete("page")
+
+    return NextResponse.rewrite(url)
+  }
+
+  url.pathname = `category/clp/${request.nextUrl.pathname.split("/")[2]}`
+
+  return NextResponse.rewrite(url)
+}
+
+function handlePLPMiddleware(request: NextRequest) {
+  const url = request.nextUrl.clone()
+
+  url.pathname = `category/plp/${request.nextUrl.pathname.split("/")[2]}`
+
+  return NextResponse.rewrite(url)
+}
+
 export const config = {
   // https://nextjs.org/docs/messages/edge-dynamic-code-evaluation
   unstable_allowDynamic: ["**/node_modules/lodash/lodash.js", "**/node_modules/reflect-metadata/Reflect.js"],
-  matcher: ["/", "/((?!api|_next|cache-healthcheck|healthz|health|ping|_vercel|.*\\..*).*)"],
+  matcher: ["/", "/((?!api|_next|cache-healthcheck|health|_vercel|.*\\..*).*)"],
+}
+
+function isCLP(request: NextRequest): boolean {
+  const isCategory = request.nextUrl.pathname.startsWith("/category/")
+  const isInternalRoute = request.nextUrl.pathname.startsWith("/category/clp/") || request.nextUrl.pathname.startsWith("/category/page/")
+  const isFaceted = facetParams.some((param) => request.nextUrl.searchParams.has(param))
+
+  return isCategory && !isFaceted && !isInternalRoute
+}
+
+function isPLP(request: NextRequest): boolean {
+  const isCategory = request.nextUrl.pathname.startsWith("/category/")
+  const isInternalRoute = request.nextUrl.pathname.startsWith("/category/plp/")
+  const isFaceted = facetParams.some((param) => request.nextUrl.searchParams.has(param))
+
+  return isCategory && isFaceted && !isInternalRoute
 }

--- a/apps/web/stores/filterTransitionStore.ts
+++ b/apps/web/stores/filterTransitionStore.ts
@@ -1,0 +1,11 @@
+import { create } from "zustand"
+
+interface FilterTransitionStore {
+  selected: string
+  set: (filter: string) => void
+}
+
+export const useFilterTransitionStore = create<FilterTransitionStore>((set) => ({
+  selected: "",
+  set: (filter: string) => set(() => ({ selected: filter })),
+}))

--- a/apps/web/stores/modalStore.ts
+++ b/apps/web/stores/modalStore.ts
@@ -1,6 +1,6 @@
 import { create } from "zustand"
 
-export type Modal = "login" | "signup" | "search"
+export type Modal = "login" | "signup" | "search" | "facets-mobile"
 
 interface ModalStore {
   modals: Partial<Record<Modal, boolean>>

--- a/apps/web/types/index.ts
+++ b/apps/web/types/index.ts
@@ -1,0 +1,1 @@
+export type SearchParamsType = Record<string, string | string[] | undefined>

--- a/apps/web/utils/filterBuilder.ts
+++ b/apps/web/utils/filterBuilder.ts
@@ -20,8 +20,6 @@ export enum SpecialOperators {
   IsNull = "IS NULL",
 }
 
-type Operator = ComparisonOperators | LogicalOperators | SpecialOperators
-
 type Value = string | number | (string | number)[]
 
 export class FilterBuilder {

--- a/apps/web/views/Category/CategoryView.tsx
+++ b/apps/web/views/Category/CategoryView.tsx
@@ -1,4 +1,8 @@
+import { storefrontClient } from "clients/storefrontClient"
+import { notFound } from "next/navigation"
 import { SearchParamsType } from "types"
+import { getDemoSingleCategory, isDemoMode } from "utils/demoUtils"
+import { HeroSection } from "views/Category/HeroSection"
 import { SearchView } from "views/Search/SearchView"
 
 interface CategoryViewProps {
@@ -7,5 +11,17 @@ interface CategoryViewProps {
 }
 
 export async function CategoryView({ params, searchParams = {} }: CategoryViewProps) {
-  return <SearchView searchParams={searchParams} params={params} disabledFacets={["category", "tags"]} collection={undefined} intro={null} />
+  const collection = isDemoMode() ? getDemoSingleCategory(params.slug) : await storefrontClient.getCollection(params.slug)
+
+  if (!collection) return notFound()
+
+  return (
+    <SearchView
+      searchParams={searchParams}
+      params={params}
+      disabledFacets={["category", "tags"]}
+      collection={collection}
+      intro={<HeroSection handle={collection.handle} title={collection.title} description={collection.description} image={collection.image} />}
+    />
+  )
 }

--- a/apps/web/views/Category/CategoryView.tsx
+++ b/apps/web/views/Category/CategoryView.tsx
@@ -1,0 +1,11 @@
+import { SearchParamsType } from "types"
+import { SearchView } from "views/Search/SearchView"
+
+interface CategoryViewProps {
+  params: { slug: string; page?: string }
+  searchParams?: SearchParamsType
+}
+
+export async function CategoryView({ params, searchParams = {} }: CategoryViewProps) {
+  return <SearchView searchParams={searchParams} params={params} disabledFacets={["category", "tags"]} collection={undefined} intro={null} />
+}

--- a/apps/web/views/Listing/FacetsMobile.tsx
+++ b/apps/web/views/Listing/FacetsMobile.tsx
@@ -4,7 +4,7 @@ import { Placeholder } from "components/GenericModal/GenericModal"
 import { FiltersIcon } from "components/Icons/FiltersIcon"
 import { CategoriesDistribution } from "meilisearch"
 import dynamic from "next/dynamic"
-import { useState } from "react"
+import { useModalStore } from "stores/modalStore"
 
 const FacetsContent = dynamic(() => import("views/Listing/FacetsContent").then((m) => m.FacetsContent))
 const GenericModal = dynamic(() => import("components/GenericModal/GenericModal").then((m) => m.GenericModal), { loading: Placeholder })
@@ -16,15 +16,15 @@ interface FacetsMobileProps {
 }
 
 export function FacetsMobile({ className, facetDistribution, disabledFacets }: FacetsMobileProps) {
-  const [isOpen, setIsOpen] = useState(false)
+  const { modals, openModal, closeModal } = useModalStore()
 
   return (
     <div className={className}>
-      <div onClick={() => setIsOpen(true)}>
+      <div onClick={() => openModal("facets-mobile")}>
         <FiltersIcon className="size-5" />
       </div>
-      {isOpen && (
-        <GenericModal className="h-full overflow-auto" title="Filters" open={isOpen} onOpenChange={() => setIsOpen(false)}>
+      {!!modals["facets-mobile"] && (
+        <GenericModal className="h-full overflow-auto" title="Filters" open={!!modals["facets-mobile"]} onOpenChange={() => closeModal("facets-mobile")}>
           <FacetsContent facetDistribution={facetDistribution} disabledFacets={disabledFacets} />
         </GenericModal>
       )}

--- a/apps/web/views/Listing/PriceFacet.tsx
+++ b/apps/web/views/Listing/PriceFacet.tsx
@@ -1,0 +1,78 @@
+import { Button } from "components/Button/Button"
+import { Input, InputProps } from "components/Input/Input"
+import { Label } from "components/Label/Label"
+import { type ChangeEvent, type KeyboardEvent, useState } from "react"
+
+interface PriceFacetProps {
+  initMin: number | null
+  initMax: number | null
+  setFacet: (facet: { minPrice: number | null; maxPrice: number | null }) => void
+}
+
+export const PriceFacet = ({ initMin, initMax, setFacet }: PriceFacetProps) => {
+  const [minPrice, setMinPrice] = useState(initMin)
+  const [maxPrice, setMaxPrice] = useState(initMax)
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    console.log({ e })
+    if (e.key === "Enter") {
+      setFacet({ minPrice, maxPrice })
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-1">
+      <div className="flex justify-between gap-4">
+        <PriceInput
+          id="min-price"
+          label="Min price"
+          value={minPrice || undefined}
+          onChange={(e) => {
+            setMinPrice(+e.target.value)
+          }}
+          onKeyDown={handleKeyDown}
+        />
+
+        <PriceInput
+          id="max-price"
+          label="Max price"
+          value={maxPrice || undefined}
+          onChange={(e) => {
+            setMaxPrice(+e.target.value)
+          }}
+          onKeyDown={handleKeyDown}
+        />
+      </div>
+      <Button
+        className="ml-auto mt-2"
+        onClick={() => {
+          setFacet({ minPrice, maxPrice })
+        }}
+      >
+        Apply
+      </Button>
+    </div>
+  )
+}
+
+interface PriceInputProps extends InputProps {
+  value: number | undefined
+  onChange: (e: ChangeEvent<HTMLInputElement>) => void
+  label: string
+}
+
+function PriceInput({ value, onChange, label, ...rest }: PriceInputProps) {
+  return (
+    <Label className="flex w-full min-w-[90px] flex-col gap-2">
+      {label}
+      <Input
+        placeholder="10.0"
+        className="block h-auto w-full rounded-md border border-neutral-300 bg-neutral-100 px-2.5 py-1.5 text-[14px] text-black focus:border-blue-500 focus:ring-blue-500  "
+        type="number"
+        value={value}
+        onChange={onChange}
+        {...rest}
+      />
+    </Label>
+  )
+}

--- a/apps/web/views/Search/SearchView.tsx
+++ b/apps/web/views/Search/SearchView.tsx
@@ -1,34 +1,29 @@
-import { PlatformProduct } from "@enterprise-commerce/core/platform/types"
-import type { Metadata } from "next"
+import { Suspense, type ReactNode } from "react"
+import { PlatformCollection, PlatformProduct } from "@enterprise-commerce/core/platform/types"
 import { unstable_cache } from "next/cache"
-import { notFound } from "next/navigation"
 import { createSearchParamsCache, parseAsArrayOf, parseAsInteger, parseAsString } from "nuqs/server"
-import { Suspense } from "react"
 import { meilisearch } from "clients/meilisearch"
-import { storefrontClient } from "clients/storefrontClient"
 
 import { MEILISEARCH_INDEX } from "constants/index"
 import { ComparisonOperators, FilterBuilder } from "utils/filterBuilder"
-import { HeroSection } from "views/Category/HeroSection"
-import { PageSkeleton } from "views/Category/PageSkeleton"
 import { composeFilters } from "views/Listing/composeFilters"
 import { FacetsDesktop } from "views/Listing/FacetsDesktop"
 import { FacetsMobile } from "views/Listing/FacetsMobile"
 import { HitsSection } from "views/Listing/HitsSection"
 import { PaginationSection } from "views/Listing/PaginationSection"
 import { Sorter } from "views/Listing/Sorter"
-import { getDemoProducts, getDemoSingleCategory, isDemoMode } from "utils/demoUtils"
+import { getDemoProducts, isDemoMode } from "utils/demoUtils"
+import { SearchParamsType } from "types"
 
-export const metadata: Metadata = {
-  title: "Search | Enterprise Commerce",
-  description: "In excepteur elit mollit in.",
+interface SearchViewProps {
+  searchParams: SearchParamsType
+  params?: { slug: string; page?: string }
+  collection?: PlatformCollection
+  disabledFacets?: string[]
+  intro?: ReactNode
 }
 
-export const runtime = "edge"
-
-export const revalidate = 3600
-
-const searchParamsCache = createSearchParamsCache({
+export const searchParamsCache = createSearchParamsCache({
   q: parseAsString.withDefault(""),
   page: parseAsInteger.withDefault(1),
   minPrice: parseAsInteger,
@@ -41,33 +36,20 @@ const searchParamsCache = createSearchParamsCache({
   sizes: parseAsArrayOf(parseAsString).withDefault([]),
 })
 
-interface CategoryPageProps {
-  searchParams: Record<string, string | string[] | undefined>
-  params: { slug: string }
-}
-
-export default async function CategoryPage({ searchParams, params }: CategoryPageProps) {
-  return (
-    <Suspense fallback={<PageSkeleton />}>
-      <SearchView searchParams={searchParams} params={params} />
-    </Suspense>
-  )
-}
-
-async function SearchView({ searchParams, params }: CategoryPageProps) {
+export async function SearchView({ searchParams, disabledFacets, intro, collection }: SearchViewProps) {
   const { q, sortBy, page, ...rest } = searchParamsCache.parse(searchParams)
-  const collection = isDemoMode() ? getDemoSingleCategory(params.slug) : await storefrontClient.getCollection(params.slug)
 
-  if (!collection) return notFound()
+  const filterBuilder = new FilterBuilder()
 
-  const filterBuilder = new FilterBuilder().where("collections.title", ComparisonOperators.Equal, collection.title)
+  if (collection) {
+    filterBuilder.where("collections.title", ComparisonOperators.Equal, collection.title)
+  }
+
   const { facetDistribution, hits, totalPages } = await searchProducts(q, sortBy, page, composeFilters(filterBuilder, rest).build())
-
-  const disabledFacets = ["category", "tags"]
 
   return (
     <div className="max-w-container-md mx-auto w-full px-4 py-12 md:py-24 xl:px-0">
-      <HeroSection handle={collection.handle} title={collection.title} description={collection.description} image={collection.image} />
+      {intro}
       <div className="flex min-h-screen w-full flex-col gap-12 md:flex-row md:gap-24">
         <FacetsDesktop disabledFacets={disabledFacets} className="hidden min-w-[250px] max-w-[250px] md:mt-16 lg:block" facetDistribution={facetDistribution} />
         <div className="flex w-full flex-col">
@@ -76,7 +58,12 @@ async function SearchView({ searchParams, params }: CategoryPageProps) {
               <div className="flex items-center justify-between">
                 <FacetsMobile disabledFacets={disabledFacets} facetDistribution={facetDistribution} className="block lg:hidden" />
               </div>
-              <Sorter className="ml-auto" />
+              {/*  has to be wrapped w. suspense, nuqs is using useSearchParams in useQueryState
+               * https://github.com/47ng/nuqs/issues/496
+               */}
+              <Suspense>
+                <Sorter className="ml-auto" />
+              </Suspense>
             </div>
 
             <HitsSection hits={hits} />

--- a/apps/web/views/Search/SearchView.tsx
+++ b/apps/web/views/Search/SearchView.tsx
@@ -1,4 +1,4 @@
-import { Suspense, type ReactNode } from "react"
+import { type ReactNode, Suspense } from "react"
 import { PlatformCollection, PlatformProduct } from "@enterprise-commerce/core/platform/types"
 import { unstable_cache } from "next/cache"
 import { createSearchParamsCache, parseAsArrayOf, parseAsInteger, parseAsString } from "nuqs/server"


### PR DESCRIPTION
- Adds routing logic to middleware
- Extracts `SearchView` for reusability
- bugfixes BloomFilter - `handleRedirectResponse` was returning `undefined` when no redirect found
- moves filters modal into global store (needed to keep the state when jumping across different page types)