### PR TITLE
fix(web): Show proper pricing when filtering

### DIFF
--- a/apps/web/components/ProductCard/ProductCard.tsx
+++ b/apps/web/components/ProductCard/ProductCard.tsx
@@ -3,8 +3,9 @@ import Image from "next/image"
 import Link from "next/link"
 import { cn } from "utils/cn"
 import { QuickAdd } from "./QuickAdd"
+import { type CurrencyType, mapCurrencyToSign } from "utils/mapCurrencyToSign"
 
-interface ProductCardProps extends Pick<PlatformProduct, "variants" | "handle" | "images" | "title" | "featuredImage"> {
+interface ProductCardProps extends Pick<PlatformProduct, "variants" | "handle" | "images" | "title" | "featuredImage" | "minPrice"> {
   priority?: boolean
   className?: string
 }
@@ -31,11 +32,14 @@ export function ProductCard(props: ProductCardProps) {
 
         <QuickAdd variants={props.variants} />
       </div>
-
       <Link aria-label={linkAria} href={href}>
         <div className="mt-4 flex flex-col gap-0.5 text-slate-700">
-          <div className="line-clamp-2 text-[13px] tracking-tight md:text-[19px]">{props.title}</div>
-          {variant ? <p className="text-[13px] font-bold tracking-tight text-black md:text-[23px] md:font-normal">{variant.amount + " " + variant.currencyCode}</p> : null}
+          <div className="line-clamp-2 text-base tracking-tight md:text-xl">{props.title}</div>
+          {!!variant && (
+            <p className="text-base font-semibold tracking-tight text-black md:text-lg">
+              From {props.minPrice.toFixed(2) + mapCurrencyToSign(variant.currencyCode as CurrencyType)}
+            </p>
+          )}
         </div>
       </Link>
     </div>

--- a/apps/web/components/ProductCard/QuickAdd.tsx
+++ b/apps/web/components/ProductCard/QuickAdd.tsx
@@ -10,7 +10,7 @@ export function QuickAdd({ variants }: QuickAddProps) {
   const combinations = getAllCombinations(variants)
 
   const hasOnlyOneCombination = combinations?.length === 1
-  const combinationsMarkup = combinations?.map((combination) => <QuickAddButton key={combination.id} combination={combination} />)
+  const combinationsMarkup = combinations?.map((combination) => <QuickAddButton key={combination.id} combination={combination} withPrice />)
 
   return (
     <div className="absolute inset-x-0 bottom-0 z-50 hidden h-0 w-full overflow-hidden bg-white transition-all group-hover:h-[90px] group-hover:border-t group-hover:border-black lg:block">

--- a/apps/web/components/ProductCard/QuickAddButton.tsx
+++ b/apps/web/components/ProductCard/QuickAddButton.tsx
@@ -7,14 +7,16 @@ import { useCartStore } from "stores/cartStore"
 import { cn } from "utils/cn"
 import { Combination } from "utils/productOptionsUtils"
 import { toast } from "sonner"
+import { type CurrencyType, mapCurrencyToSign } from "utils/mapCurrencyToSign"
 
 interface QuickAddButtonProps {
   combination: Combination | undefined
   label?: string
   className?: string
+  withPrice?: boolean
 }
 
-export default function QuickAddButton({ combination, label, className }: QuickAddButtonProps) {
+export default function QuickAddButton({ combination, label, className, withPrice = false }: QuickAddButtonProps) {
   const [isPending, startTransition] = useTransition()
   const openCart = useCartStore((s) => s.openCart)
 
@@ -41,11 +43,30 @@ export default function QuickAddButton({ combination, label, className }: QuickA
       onClick={handleClick}
       disabled={isPending}
       className={cn(
-        "relative flex min-h-[30px] w-[70px] cursor-pointer justify-center truncate text-nowrap border border-black bg-white p-1.5 text-[11px] uppercase transition-colors hover:bg-neutral-800 hover:text-white disabled:cursor-not-allowed disabled:hover:text-black",
+        "relative flex min-h-[30px] cursor-pointer justify-center border border-black bg-white p-1.5 text-[11px] uppercase transition-colors hover:bg-neutral-800 hover:text-white disabled:cursor-not-allowed disabled:hover:text-black",
         className
       )}
     >
-      {isPending ? <Spinner className="size-4" /> : label || combination.title}
+      {isPending ? <Spinner className="size-4" /> : <QuickAddButtonLabel label={label || combination.title} price={withPrice ? combination.price : undefined} />}
     </button>
+  )
+}
+
+type QuickAddButtonLabelProps = {
+  label: string
+  price?: Combination["price"]
+}
+
+function QuickAddButtonLabel({ label, price }: QuickAddButtonLabelProps) {
+  return (
+    <div className="flex h-full flex-col">
+      <p className="whitespace-nowrap px-1">{label}</p>
+      {!!price && (
+        <span className="mt-auto">
+          {(+price.amount).toFixed(2)}
+          {mapCurrencyToSign(price?.currencyCode as CurrencyType)}
+        </span>
+      )}
+    </div>
   )
 }

--- a/apps/web/utils/mapCurrencyToSign.ts
+++ b/apps/web/utils/mapCurrencyToSign.ts
@@ -1,0 +1,15 @@
+export type CurrencyType = "USD" | "EUR" | "GBP"
+
+export function mapCurrencyToSign(currency: CurrencyType) {
+  switch (currency) {
+    case "USD":
+      return "$"
+    case "EUR":
+      return "€"
+    case "GBP":
+      return "£"
+
+    default:
+      return currency
+  }
+}

--- a/apps/web/views/Listing/composeFilters.ts
+++ b/apps/web/views/Listing/composeFilters.ts
@@ -34,11 +34,11 @@ export function composeFilters(filter: FilterBuilder, parsedSearchParams: MakeFi
     },
     {
       predicate: !!parsedSearchParams.minPrice,
-      action: () => filter.and().where("minPrice", ComparisonOperators.GreaterThan, parsedSearchParams.minPrice!),
+      action: () => filter.and().where("minPrice", ComparisonOperators.GreaterThanOrEqual, parsedSearchParams.minPrice!),
     },
     {
       predicate: !!parsedSearchParams.maxPrice,
-      action: () => filter.and().where("minPrice", ComparisonOperators.LessThan, parsedSearchParams.maxPrice!),
+      action: () => filter.and().where("minPrice", ComparisonOperators.LessThanOrEqual, parsedSearchParams.maxPrice!),
     },
   ]
 


### PR DESCRIPTION
- Changes UI to`From {minPrice}` for product cards
    - when filtering it was confusing to see random prices especially once applied from/to
- Now price shows for every variant inside quick add too 
- It can be refactored with `new Number.Intl` if we found using manual mapper too disturbing, but that needs to standardise price format 

example:
![CleanShot 2024-04-15 at 9  06 44](https://github.com/Blazity/enterprise-commerce/assets/19807029/86d4c897-0fe4-4726-a992-78be94d258a0)



after:
![CleanShot 2024-04-15 at 9  07 10](https://github.com/Blazity/enterprise-commerce/assets/19807029/29863996-ff53-4120-9443-c712cc368a1f)
