### PR TITLE
fix(web): Prevent navigation on mobile nav click

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -185,7 +185,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="en">
       <body>
-        <Script id="mobileMegaMenuLogic" strategy="beforeInteractive">{`${mobileInlineScript}`}</Script>
+        <Script id="mobileMegaMenuLogic" strategy="lazyOnload">{`${mobileInlineScript}`}</Script>
 
         <TopBar />
         <NavigationBar items={navigationItems} />

--- a/apps/web/components/NavigationBar/NavigationBar.tsx
+++ b/apps/web/components/NavigationBar/NavigationBar.tsx
@@ -13,6 +13,7 @@ import { Skeleton } from "components/Skeleton/Skeleton"
 import { CloseIcon } from "components/Icons/CloseIcon"
 import { ProfileMenu } from "components/ProfileMenu/ProfileMenu"
 import { SearchButton } from "./SearchButton"
+import { NavigationItem } from "./NavigationItem"
 
 interface NavigationBarProps {
   items: NavItem[]
@@ -36,17 +37,15 @@ function VariantGrid({ variant, items }: { variant?: "text-grid" | "image-grid" 
 export function NavigationBar({ items }: NavigationBarProps) {
   const itemsMarkup = items.map((singleMenuItem) => (
     <li className={cn("menu__item", { menu__dropdown: !!singleMenuItem.submenu })} key={singleMenuItem.text}>
-      <a href={singleMenuItem.href || "#"} className="menu__link text-[22px] hover:underline md:text-sm/[18px]">
-        {singleMenuItem.text}
-        {!!singleMenuItem.submenu && (
-          <i>
-            <ChevronIcon />
-          </i>
-        )}
-      </a>
+      <NavigationItem singleMenuItem={singleMenuItem} />
 
       <div className="submenu megamenu__text w-full border-b border-black shadow-sm">
         <VariantGrid items={singleMenuItem.submenu?.items} variant={singleMenuItem.submenu?.variant} />
+        <div className="submenu__inner flex w-full flex-col gap-4 md:hidden">
+          <a href={singleMenuItem.href || "#"}>
+            <h4 className="mb-20 text-center text-xl underline">See all {singleMenuItem.text}</h4>
+          </a>
+        </div>
       </div>
     </li>
   ))

--- a/apps/web/components/NavigationBar/NavigationItem.tsx
+++ b/apps/web/components/NavigationBar/NavigationItem.tsx
@@ -1,0 +1,24 @@
+"use client"
+
+import type { MouseEvent } from "react"
+import { ChevronIcon } from "components/Icons/ChevronIcon"
+import { NavItem } from "./types"
+
+export function NavigationItem({ singleMenuItem }: { singleMenuItem: NavItem }) {
+  const handleClick = (e: MouseEvent<HTMLAnchorElement>) => {
+    if (singleMenuItem.submenu && window.innerWidth < 768) {
+      e.preventDefault()
+    }
+  }
+
+  return (
+    <a onClick={handleClick} href={singleMenuItem.href || "#"} className="menu__link text-[22px] hover:underline md:text-sm/[18px]">
+      {singleMenuItem.text}
+      {!!singleMenuItem.submenu && (
+        <i>
+          <ChevronIcon />
+        </i>
+      )}
+    </a>
+  )
+}

--- a/apps/web/components/NavigationBar/variants/ImageGridVariant.tsx
+++ b/apps/web/components/NavigationBar/variants/ImageGridVariant.tsx
@@ -10,7 +10,7 @@ export function ImageGridVariant({ items }: ImageGridVariantProps) {
   if (!items) return null
 
   return (
-    <div className="max-w-container-md mx-auto my-20 grid w-full grid-cols-[repeat(_auto-fit,minmax(200px,1fr)_)] gap-8 px-4 md:my-0 md:py-14 xl:px-0">
+    <div className="max-w-container-md mx-auto mb-10 mt-20 grid w-full grid-cols-[repeat(_auto-fit,minmax(200px,1fr)_)] gap-8 px-4 md:my-0 md:py-14 xl:px-0">
       {items.map((singleCategory) => (
         <Link prefetch={false} href={singleCategory.href} className="submenu__inner flex flex-col items-center gap-4" key={singleCategory.text}>
           <Image

--- a/apps/web/components/NavigationBar/variants/TextGridVariant.tsx
+++ b/apps/web/components/NavigationBar/variants/TextGridVariant.tsx
@@ -9,7 +9,7 @@ export function TextGridVariant({ items }: TextGridVariantProps) {
   if (!items) return null
 
   return (
-    <div className="max-w-container-md mx-auto my-20 grid w-full grid-cols-[repeat(_auto-fit,minmax(250px,1fr)_)] gap-8 px-4 md:my-0 md:py-14 xl:px-0">
+    <div className="max-w-container-md mx-auto mb-10 mt-20 grid w-full grid-cols-[repeat(_auto-fit,minmax(250px,1fr)_)] gap-8 px-4 md:my-0 md:py-14 xl:px-0">
       {items.map((singleCategory) => (
         <div className="submenu__inner flex w-full flex-col gap-4" key={singleCategory.text}>
           <h4 className="submenu__title text-[22px]">{singleCategory.text}</h4>

--- a/apps/web/components/NavigationBar/variants/TextImageGridVariant.tsx
+++ b/apps/web/components/NavigationBar/variants/TextImageGridVariant.tsx
@@ -13,7 +13,7 @@ export function TextImageGridVariant({ items }: TextImageGridVariantProps) {
   const imageItems = items.filter((item) => item.image).slice(0, 3)
 
   return (
-    <div className="max-w-container-md mx-auto my-20 flex w-full flex-wrap justify-between gap-4 px-4 md:my-0 md:flex-nowrap md:gap-10 md:py-14 xl:px-0">
+    <div className="max-w-container-md mx-auto mb-10 mt-20 flex w-full flex-wrap justify-between gap-4 px-4 md:my-0 md:flex-nowrap md:gap-10 md:py-14 xl:px-0">
       <div className="flex w-full flex-col gap-2 text-center md:w-1/2 md:text-left">
         <ul>
           {textItems.map((item) => (


### PR DESCRIPTION
- Changes script loading strategy for custom mobile nav scripts to lazyOnload -- these are not critical on initial render, should not be render blocking also this won't be working at all without JS
- Adds handler to prevent navigation for mobile navigation item click
- Adds 'see all x' as replacement