### PR TITLE
refactor(web): move og to node, as edge hits free plan limits

### DIFF
--- a/apps/web/app/products/[slug]/opengraph-image.tsx
+++ b/apps/web/app/products/[slug]/opengraph-image.tsx
@@ -5,8 +5,6 @@ import { ImageResponse } from "next/og"
 import { getProduct } from "app/actions/product.actions"
 import { removeOptionsFromUrl } from "utils/productOptionsUtils"
 
-export const runtime = "edge"
-
 export const revalidate = 3600
 
 export const dynamic = "force-static"

--- a/apps/web/app/search/opengraph-image.tsx
+++ b/apps/web/app/search/opengraph-image.tsx
@@ -3,8 +3,6 @@
 
 import { ImageResponse } from "next/og"
 
-export const runtime = "edge"
-
 export const revalidate = 3600
 
 export const dynamic = "force-static"


### PR DESCRIPTION
- Currently when using vercel deploy button it is possible for a user on a free vercel plan to hit vercel edge limit
![CleanShot 2024-04-17 at 10  30 07](https://github.com/Blazity/enterprise-commerce/assets/19807029/2796c538-6f33-444a-9976-5912e698da5d)
