### PR TITLE
refactor(web): search for clp/srp

### DIFF
--- a/apps/web/components/NavigationBar/Autocomplete.tsx
+++ b/apps/web/components/NavigationBar/Autocomplete.tsx
@@ -21,13 +21,10 @@ interface AutocompleteProps {
 
 export function Autocomplete({ className }: AutocompleteProps) {
   const router = useRouter()
-
   const [isOpen, setIsOpen] = useState(false)
-
   const { query, results, isPending, onChange, status } = useAutocomplete({
     callback: () => !isOpen && setIsOpen(true),
   })
-
   const ref = useClickAway<HTMLDivElement>(() => {
     setIsOpen(false)
   })

--- a/apps/web/components/ProductCard/ProductCard.tsx
+++ b/apps/web/components/ProductCard/ProductCard.tsx
@@ -35,7 +35,7 @@ export function ProductCard(props: ProductCardProps) {
       <Link aria-label={linkAria} href={href}>
         <div className="mt-4 flex flex-col gap-0.5 text-slate-700">
           <div className="line-clamp-2 text-base tracking-tight md:text-xl">{props.title}</div>
-          {!!variant && (
+          {!!variant && !!props.minPrice && (
             <p className="text-base font-semibold tracking-tight text-black md:text-lg">
               From {props.minPrice.toFixed(2) + mapCurrencyToSign(variant.currencyCode as CurrencyType)}
             </p>

--- a/apps/web/views/Listing/FacetsContent.tsx
+++ b/apps/web/views/Listing/FacetsContent.tsx
@@ -1,13 +1,18 @@
 "use client"
 
-import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "components/Accordion/Accordion"
-import { SearchIcon } from "components/Icons/SearchIcon"
+import { Suspense } from "react"
 import type { CategoriesDistribution } from "meilisearch"
 import { parseAsArrayOf, parseAsInteger, parseAsString, useQueryState } from "nuqs"
+
+import { useFilterTransitionStore } from "stores/filterTransitionStore"
+
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "components/Accordion/Accordion"
+import { SearchIcon } from "components/Icons/SearchIcon"
+
 import { Facet } from "./Facet"
 import { CategoryFacet } from "./CategoryFacet"
-import { useFilterTransitionStore } from "stores/filterTransitionStore"
 import { PriceFacet } from "./PriceFacet"
+import { Sorter } from "./Sorter"
 
 interface FacetsContentProps {
   facetDistribution: Record<string, CategoriesDistribution> | undefined
@@ -42,7 +47,6 @@ export function FacetsContent({ facetDistribution, className, disabledFacets }: 
   const [selectedColors, setSelectedColors] = useQueryState("colors", { ...parseAsArrayOf(parseAsString), defaultValue: [], shallow: false, history: "push", clearOnDefault: true })
   const [selectedSizes, setSelectedSizes] = useQueryState("sizes", { ...parseAsArrayOf(parseAsString), defaultValue: [], shallow: false, history: "push", clearOnDefault: true })
 
-  const [query, setQuery] = useQueryState("q", { shallow: false })
   const [_, setPage] = useQueryState("page", { ...parseAsInteger, defaultValue: 1, shallow: false, history: "push", clearOnDefault: true })
 
   const [minPrice, setMinPrice] = useQueryState("minPrice", { ...parseAsInteger, shallow: false, defaultValue: 0, clearOnDefault: true })
@@ -64,6 +68,9 @@ export function FacetsContent({ facetDistribution, className, disabledFacets }: 
 
   return (
     <div className={className}>
+      <Suspense>
+        <Sorter className="shrink-0 basis-[200px] self-center lg:hidden" />
+      </Suspense>
       {!disabledFacets?.includes("category") ? (
         <CategoryFacet
           title="categories"
@@ -79,16 +86,6 @@ export function FacetsContent({ facetDistribution, className, disabledFacets }: 
         <div className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3.5">
           <SearchIcon className="size-4 text-neutral-500" />
         </div>
-        <input
-          className="block w-full rounded-md border border-neutral-300 bg-neutral-100 px-2.5 py-1.5 pl-10 text-[14px] text-black focus:border-blue-500 focus:ring-blue-500"
-          placeholder="Search..."
-          type="search"
-          value={query || ""}
-          onChange={(event) => {
-            setQuery(event.target.value)
-            setPage(1)
-          }}
-        />
       </div>
 
       <Accordion collapsible className="w-full" type="single" defaultValue={lastSelected}>

--- a/apps/web/views/Listing/SearchFacet.tsx
+++ b/apps/web/views/Listing/SearchFacet.tsx
@@ -1,0 +1,49 @@
+"use client"
+
+import { parseAsInteger, useQueryState } from "nuqs"
+import { useDebounce } from "@uidotdev/usehooks"
+import { cn } from "utils/cn"
+import { useEffect, useState } from "react"
+import { CloseIcon } from "components/Icons/CloseIcon"
+import { Button } from "components/Button/Button"
+
+export function SearchFacet({ className }: { className?: string }) {
+  const [query, setQuery] = useQueryState("q", { shallow: false })
+  const [localQuery, setLocalQuery] = useState(query)
+  const [_, setPage] = useQueryState("page", { ...parseAsInteger, defaultValue: 1, shallow: false, history: "push", clearOnDefault: true })
+
+  const debouncedQuery = useDebounce(localQuery, 500)
+
+  useEffect(() => {
+    if (!debouncedQuery) return
+
+    setPage(1)
+    setQuery(debouncedQuery)
+  }, [debouncedQuery, setPage, setQuery])
+
+  return (
+    <div className={cn("relative flex items-center justify-center", className)}>
+      <input
+        className="relative w-full appearance-none rounded-md border border-neutral-300 bg-neutral-100 px-2.5 py-1.5 pl-4 text-black focus:border-blue-500 focus:ring-blue-500"
+        placeholder="Search..."
+        type="text"
+        value={localQuery || ""}
+        onChange={(event) => {
+          setLocalQuery(event.target.value)
+        }}
+      />
+      {!!localQuery && (
+        <Button
+          onClick={() => {
+            setQuery("")
+            setLocalQuery("")
+          }}
+          variant="ghost"
+          className="absolute right-2 p-2"
+        >
+          <CloseIcon />
+        </Button>
+      )}
+    </div>
+  )
+}

--- a/apps/web/views/Listing/Sorter.tsx
+++ b/apps/web/views/Listing/Sorter.tsx
@@ -35,8 +35,8 @@ export function Sorter({ className }: SorterProps) {
     <div className={className}>
       <DropdownMenu>
         <DropdownMenuTrigger aria-expanded={undefined} asChild>
-          <div className="inline-flex cursor-pointer items-center justify-center gap-1.5 text-[15px] text-black">
-            Sort by <span className="text-slate-700 underline">{LABELS[sortBy]}</span>
+          <div className="flex cursor-pointer flex-wrap items-center justify-center gap-0.5 text-[15px] text-black">
+            Sort by: <span className="ml-0.5 text-slate-700 underline">{LABELS[sortBy]}</span>
             <ChevronIcon />
           </div>
         </DropdownMenuTrigger>

--- a/apps/web/views/Search/SearchView.tsx
+++ b/apps/web/views/Search/SearchView.tsx
@@ -11,6 +11,7 @@ import { FacetsDesktop } from "views/Listing/FacetsDesktop"
 import { FacetsMobile } from "views/Listing/FacetsMobile"
 import { HitsSection } from "views/Listing/HitsSection"
 import { PaginationSection } from "views/Listing/PaginationSection"
+import { SearchFacet } from "views/Listing/SearchFacet"
 import { Sorter } from "views/Listing/Sorter"
 import { getDemoProducts, isDemoMode } from "utils/demoUtils"
 import { SearchParamsType } from "types"
@@ -54,15 +55,18 @@ export async function SearchView({ searchParams, disabledFacets, intro, collecti
         <FacetsDesktop disabledFacets={disabledFacets} className="hidden min-w-[250px] max-w-[250px] md:mt-16 lg:block" facetDistribution={facetDistribution} />
         <div className="flex w-full flex-col">
           <div className="mb-6 flex w-full flex-wrap items-center justify-between">
-            <div className="flex w-full flex-col gap-2 pb-8">
-              <div className="flex items-center justify-between">
+            <div className="flex w-full gap-2 pb-8">
+              <div className="flex items-center justify-between gap-4">
                 <FacetsMobile disabledFacets={disabledFacets} facetDistribution={facetDistribution} className="block lg:hidden" />
               </div>
+              <Suspense>
+                <SearchFacet className="grow" />
+              </Suspense>
               {/*  has to be wrapped w. suspense, nuqs is using useSearchParams in useQueryState
                * https://github.com/47ng/nuqs/issues/496
                */}
               <Suspense>
-                <Sorter className="ml-auto" />
+                <Sorter className="ml-auto hidden shrink-0 basis-[200px] self-center lg:block" />
               </Suspense>
             </div>
 


### PR DESCRIPTION
Resolves: https://github.com/orgs/Blazity/projects/3/views/3?pane=issue&itemId=61444741

- Adds search input field for CLP/PLP/SRP for instant search within product grid
- Tried with functionality for instant search on SRP via the top search, but that defo wasn't a good UX on mobile devices