### PR TITLE
feat(web): sync-products & cron

### DIFF
--- a/apps/web/app/actions/product.actions.ts
+++ b/apps/web/app/actions/product.actions.ts
@@ -4,11 +4,11 @@ import { unstable_cache } from "next/cache"
 import { env } from "env.mjs"
 
 import { meilisearch } from "clients/meilisearch"
-import type { PlatformProduct } from "@enterprise-commerce/core/platform/types"
 import type { Review } from "@enterprise-commerce/reviews"
 
 import { ComparisonOperators, FilterBuilder } from "utils/filterBuilder"
 import { getDemoSingleProduct, isDemoMode } from "utils/demoUtils"
+import { CommerceProduct } from "types"
 
 export const searchProducts = unstable_cache(
   async (query: string, limit: number = 4) => {
@@ -17,7 +17,7 @@ export const searchProducts = unstable_cache(
         hits: [],
         hasMore: false,
       }
-    const index = await meilisearch?.getIndex<PlatformProduct>(env.MEILISEARCH_PRODUCTS_INDEX!)
+    const index = await meilisearch?.getIndex<CommerceProduct>(env.MEILISEARCH_PRODUCTS_INDEX!)
 
     if (!index) return { hits: [], hasMore: false }
 
@@ -33,7 +33,7 @@ export const getProduct = unstable_cache(
   async (handle: string) => {
     if (isDemoMode()) return getDemoSingleProduct(handle)
 
-    const index = await meilisearch?.getIndex<PlatformProduct>(env.MEILISEARCH_PRODUCTS_INDEX!)
+    const index = await meilisearch?.getIndex<CommerceProduct>(env.MEILISEARCH_PRODUCTS_INDEX!)
     const documents = await index?.getDocuments({ filter: new FilterBuilder().where("handle", ComparisonOperators.Equal, handle).build(), limit: 1 })
     return documents.results.find(Boolean) || null
   },

--- a/apps/web/app/actions/product.actions.ts
+++ b/apps/web/app/actions/product.actions.ts
@@ -17,7 +17,7 @@ export const searchProducts = unstable_cache(
         hits: [],
         hasMore: false,
       }
-    const index = await meilisearch?.getIndex<PlatformProduct>(env.MEILISEARCH_PRODUCTS_INDEX)
+    const index = await meilisearch?.getIndex<PlatformProduct>(env.MEILISEARCH_PRODUCTS_INDEX!)
 
     if (!index) return { hits: [], hasMore: false }
 
@@ -33,7 +33,7 @@ export const getProduct = unstable_cache(
   async (handle: string) => {
     if (isDemoMode()) return getDemoSingleProduct(handle)
 
-    const index = await meilisearch?.getIndex<PlatformProduct>(env.MEILISEARCH_PRODUCTS_INDEX)
+    const index = await meilisearch?.getIndex<PlatformProduct>(env.MEILISEARCH_PRODUCTS_INDEX!)
     const documents = await index?.getDocuments({ filter: new FilterBuilder().where("handle", ComparisonOperators.Equal, handle).build(), limit: 1 })
     return documents.results.find(Boolean) || null
   },

--- a/apps/web/app/api/reviews/sync-products/route.ts
+++ b/apps/web/app/api/reviews/sync-products/route.ts
@@ -1,0 +1,84 @@
+import type { Review } from "@enterprise-commerce/reviews"
+import { meilisearch } from "clients/meilisearch"
+import { env } from "env.mjs"
+import type { CommerceProduct } from "types"
+
+export const maxDuration = 120 // seconds
+
+/* This API route runs via cron job, and updates products index (daily) to sync avgRating and total reviews with the reviews index */
+
+export async function POST(req: Request) {
+  const authHeader = req.headers.get("authorization")
+  if (authHeader !== `Bearer ${env.CRON_SECRET}`) {
+    return new Response("Unauthorized", {
+      status: 401,
+    })
+  }
+
+  if (!env.MEILISEARCH_PRODUCTS_INDEX || !env.MEILISEARCH_REVIEWS_INDEX) {
+    console.error({
+      message: "Lacking environment variables",
+      source: "api/reviews/sync-products",
+    })
+    return new Response(JSON.stringify({ message: "Sorry, something went wrong" }), { status: 500 })
+  }
+
+  const productsIndex = meilisearch?.index(env.MEILISEARCH_PRODUCTS_INDEX)
+  const reviewsIndex = meilisearch?.index(env.MEILISEARCH_REVIEWS_INDEX)
+
+  if (!productsIndex || !reviewsIndex) {
+    console.error({
+      message: "No index found",
+      source: "api/reviews/sync-products",
+    })
+    return new Response(JSON.stringify({ message: "Sorry, something went wrong" }), { status: 500 })
+  }
+
+  // Potentially will need to paginate later on
+  const allProducts = await productsIndex?.getDocuments<CommerceProduct>({
+    limit: 10000,
+  })
+
+  // Potentially will need to paginate later on
+  const allReviews = await reviewsIndex?.getDocuments<Review>({
+    limit: 10000,
+    filter: `published=true AND hidden=false`,
+  })
+
+  const mappedReviews = allReviews?.results.reduce(
+    (acc, review) => {
+      const productHandle = review.product_handle
+      if (acc[productHandle]) {
+        acc[productHandle].push(review)
+      } else {
+        acc[productHandle] = [review]
+      }
+      return acc
+    },
+    {} as Record<string, Review[]>
+  )
+
+  const delta = allProducts?.results.filter((product) => {
+    const totalReviews = product.totalReviews
+    const newReviews = mappedReviews[product.handle]?.length || 0
+
+    return totalReviews !== newReviews
+  })
+
+  if (!delta.length) {
+    return new Response(JSON.stringify({ message: "No products to sync" }), { status: 200 })
+  }
+
+  const updatedProducts = delta.map((product) => {
+    const newProduct = { ...product } // Shallow copy and to prevent mutating the original objects
+
+    newProduct.totalReviews = mappedReviews[product.handle]?.length || 0
+    newProduct.avgRating = mappedReviews[product.handle]?.reduce((acc, review) => acc + review.rating, 0) / mappedReviews[product.handle]?.length || 0
+
+    return newProduct
+  })
+
+  productsIndex.updateDocuments(updatedProducts, { primaryKey: "id" })
+
+  return new Response(JSON.stringify({ message: "Reviews synced" }), { status: 200 })
+}

--- a/apps/web/app/api/reviews/sync-products/route.ts
+++ b/apps/web/app/api/reviews/sync-products/route.ts
@@ -6,7 +6,6 @@ import type { CommerceProduct } from "types"
 export const maxDuration = 120 // seconds
 
 /* This API route runs via cron job, and updates products index (daily) to sync avgRating and total reviews with the reviews index */
-
 export async function POST(req: Request) {
   const authHeader = req.headers.get("authorization")
   if (authHeader !== `Bearer ${env.CRON_SECRET}`) {
@@ -34,12 +33,10 @@ export async function POST(req: Request) {
     return new Response(JSON.stringify({ message: "Sorry, something went wrong" }), { status: 500 })
   }
 
-  // Potentially will need to paginate later on
   const allProducts = await productsIndex?.getDocuments<CommerceProduct>({
     limit: 10000,
   })
 
-  // Potentially will need to paginate later on
   const allReviews = await reviewsIndex?.getDocuments<Review>({
     limit: 10000,
     filter: `published=true AND hidden=false`,
@@ -70,7 +67,7 @@ export async function POST(req: Request) {
   }
 
   const updatedProducts = delta.map((product) => {
-    const newProduct = { ...product } // Shallow copy and to prevent mutating the original objects
+    const newProduct = { ...product }
 
     newProduct.totalReviews = mappedReviews[product.handle]?.length || 0
     newProduct.avgRating = mappedReviews[product.handle]?.reduce((acc, review) => acc + review.rating, 0) / mappedReviews[product.handle]?.length || 0

--- a/apps/web/app/api/sync/route.ts
+++ b/apps/web/app/api/sync/route.ts
@@ -28,7 +28,7 @@ export async function POST(req: Request) {
 
   const { product, metadata } = JSON.parse(rawPayload) as Root
 
-  let index = await getMeilisearchIndex(env.MEILISEARCH_PRODUCTS_INDEX)
+  let index = await getMeilisearchIndex(env.MEILISEARCH_PRODUCTS_INDEX!)
 
   // await updateAttributesSettings(index)
 

--- a/apps/web/app/api/sync/route.ts
+++ b/apps/web/app/api/sync/route.ts
@@ -1,4 +1,4 @@
-import { PlatformImage, PlatformProduct } from "@enterprise-commerce/core/platform/types"
+import type { PlatformImage, PlatformProduct } from "@enterprise-commerce/core/platform/types"
 import { FailedAttemptError } from "p-retry"
 import { meilisearch } from "clients/meilisearch"
 import { replicate } from "clients/replicate"

--- a/apps/web/app/products/[slug]/draft/page.tsx
+++ b/apps/web/app/products/[slug]/draft/page.tsx
@@ -1,9 +1,8 @@
-import { PlatformProduct } from "@enterprise-commerce/core/platform/types"
+import type { PlatformProduct } from "@enterprise-commerce/core/platform/types"
 import { unstable_cache } from "next/cache"
 import { draftMode } from "next/headers"
 import { notFound } from "next/navigation"
 import { Suspense } from "react"
-import { getProduct } from "app/actions/product.actions"
 import { storefrontClient } from "clients/storefrontClient"
 import { Breadcrumbs } from "components/Breadcrumbs/Breadcrumbs"
 
@@ -17,6 +16,7 @@ import { SimilarProductsSection } from "views/Product/SimilarProductsSection"
 import { SimilarProductsSectionSkeleton } from "views/Product/SimilarProductsSectionSkeleton"
 import { VariantsSection } from "views/Product/VariantsSection"
 import { slugToName } from "utils/slug-name"
+import type { CommerceProduct } from "types"
 
 export const dynamic = "force-static"
 
@@ -50,7 +50,7 @@ async function ProductView({ slug }: { slug: string }) {
     return notFound()
   }
 
-  const combination = getCombination(product, color, size)
+  const combination = getCombination(product as CommerceProduct, color, size)
   const lastCollection = product?.collections?.findLast(Boolean)
   const hasOnlyOneVariant = product.variants.length <= 1
 
@@ -66,7 +66,7 @@ async function ProductView({ slug }: { slug: string }) {
           <div className="flex flex-col items-start pt-12">
             <InfoSection className="pb-10" title={product.title} description={product.descriptionHtml} combination={combination} />
             {hasOnlyOneVariant ? null : <VariantsSection combination={combination} handle={product.handle} variants={product.variants} />}
-            <DetailsSection slug={slug} product={product} />
+            <DetailsSection slug={slug} product={product as CommerceProduct} />
           </div>
         </div>
       </main>
@@ -80,7 +80,7 @@ async function ProductView({ slug }: { slug: string }) {
 async function getDraftAwareProduct(slug: string) {
   const draft = draftMode()
 
-  let product = await getProduct(removeOptionsFromUrl(slug))
+  let product = await storefrontClient.getProductByHandle(removeOptionsFromUrl(slug))
   if (draft.isEnabled && product) product = await getAdminProduct(product?.id)
 
   return product

--- a/apps/web/app/products/[slug]/metadata.ts
+++ b/apps/web/app/products/[slug]/metadata.ts
@@ -1,4 +1,3 @@
-import { PlatformProduct } from "@enterprise-commerce/core/platform/types"
 import { Metadata } from "next"
 import { Product, WithContext } from "schema-dts"
 import { getProduct } from "app/actions/product.actions"
@@ -6,6 +5,7 @@ import { env } from "env.mjs"
 import { makeKeywords } from "utils/makeKeywords"
 import { removeOptionsFromUrl } from "utils/productOptionsUtils"
 import { slugToName } from "utils/slug-name"
+import type { CommerceProduct } from "types"
 
 interface ProductProps {
   params: { slug: string }
@@ -36,7 +36,7 @@ export async function generateMetadata({ params: { slug } }: ProductProps): Prom
   }
 }
 
-export function generateJsonLd(product: PlatformProduct, slug: string) {
+export function generateJsonLd(product: CommerceProduct, slug: string) {
   return {
     "@context": "https://schema.org",
     "@type": "Product",

--- a/apps/web/app/products/[slug]/page.tsx
+++ b/apps/web/app/products/[slug]/page.tsx
@@ -18,8 +18,6 @@ import { slugToName } from "utils/slug-name"
 import { generateJsonLd } from "./metadata"
 import { ReviewsSection } from "views/Product/ReviewsSection"
 
-import { generateJsonLd } from "./metadata"
-import { ReviewsSection } from "views/Product/ReviewsSection"
 import type { CommerceProduct } from "types"
 
 export const revalidate = 3600

--- a/apps/web/app/products/[slug]/page.tsx
+++ b/apps/web/app/products/[slug]/page.tsx
@@ -19,6 +19,9 @@ import { slugToName } from "utils/slug-name"
 import { generateJsonLd } from "./metadata"
 import { ReviewsSection } from "views/Product/ReviewsSection"
 
+import { generateJsonLd } from "./metadata"
+import { ReviewsSection } from "views/Product/ReviewsSection"
+
 export const revalidate = 3600
 
 export const dynamic = "force-static"

--- a/apps/web/app/products/[slug]/page.tsx
+++ b/apps/web/app/products/[slug]/page.tsx
@@ -1,4 +1,3 @@
-import { PlatformProduct } from "@enterprise-commerce/core/platform/types"
 import { notFound } from "next/navigation"
 import { Suspense } from "react"
 import { getProduct, getProductReviews } from "app/actions/product.actions"
@@ -21,6 +20,7 @@ import { ReviewsSection } from "views/Product/ReviewsSection"
 
 import { generateJsonLd } from "./metadata"
 import { ReviewsSection } from "views/Product/ReviewsSection"
+import type { CommerceProduct } from "types"
 
 export const revalidate = 3600
 
@@ -93,7 +93,7 @@ async function ProductView({ slug }: { slug: string }) {
   )
 }
 
-function makeBreadcrumbs(product: PlatformProduct) {
+function makeBreadcrumbs(product: CommerceProduct) {
   const lastCollection = product.collections?.findLast(Boolean)
 
   return {

--- a/apps/web/app/products/[slug]/page.tsx
+++ b/apps/web/app/products/[slug]/page.tsx
@@ -71,7 +71,14 @@ async function ProductView({ slug }: { slug: string }) {
             <FavoriteMarker handle={product.handle} />
           </GallerySection>
           <div className="flex flex-col items-start pt-12">
-            <InfoSection className="pb-6" title={product.title} description={product.descriptionHtml} combination={combination} />
+            <InfoSection
+              className="pb-6"
+              title={product.title}
+              description={product.descriptionHtml}
+              combination={combination}
+              avgRating={product.avgRating}
+              totalReviews={product.totalReviews}
+            />
             {hasOnlyOneVariant ? null : <VariantsSection combination={combination} handle={product.handle} className="pb-4" variants={product.variants} />}
 
             <DetailsSection slug={slug} product={product} />

--- a/apps/web/app/reviews/[slug]/page.tsx
+++ b/apps/web/app/reviews/[slug]/page.tsx
@@ -1,4 +1,3 @@
-import { PlatformProduct } from "@enterprise-commerce/core/platform/types"
 import { notFound, redirect } from "next/navigation"
 import { getProduct, getProductReviews } from "app/actions/product.actions"
 import { Breadcrumbs } from "components/Breadcrumbs/Breadcrumbs"
@@ -8,6 +7,7 @@ import { StarRating } from "views/Product/StarRating"
 import { PaginationSection } from "views/Listing/PaginationSection"
 
 import { removeOptionsFromUrl } from "utils/productOptionsUtils"
+import type { CommerceProduct } from "types"
 
 export { generateMetadata } from "./metadata"
 
@@ -97,7 +97,7 @@ async function ProductReviewsView({ slug, searchParams }: { slug: string; search
   )
 }
 
-function makeBreadcrumbs(product: PlatformProduct) {
+function makeBreadcrumbs(product: CommerceProduct) {
   const lastCollection = product.collections?.findLast(Boolean)
 
   return {

--- a/apps/web/app/sitemap.ts
+++ b/apps/web/app/sitemap.ts
@@ -2,8 +2,9 @@ import { env } from "env.mjs"
 import { MetadataRoute } from "next"
 import { meilisearch } from "clients/meilisearch"
 import { getDemoCategories, getDemoProducts, isDemoMode } from "utils/demoUtils"
-import { PlatformCollection, PlatformProduct } from "@enterprise-commerce/core/platform/types"
+import type { PlatformCollection } from "@enterprise-commerce/core/platform/types"
 import { storefrontClient } from "clients/storefrontClient"
+import type { CommerceProduct } from "types"
 
 export const revalidate = 604800
 export const runtime = "edge"
@@ -37,14 +38,14 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     },
   ]
 
-  let allHits: PlatformProduct[] = []
+  let allHits: CommerceProduct[] = []
   let allCollections: PlatformCollection[] = []
   let finished = false
   let page = 0
 
   if (!isDemoMode()) {
     while (finished === false) {
-      const response = await (await meilisearch.getIndex(env.MEILISEARCH_PRODUCTS_INDEX)).getDocuments<PlatformProduct>({ limit: 100, offset: page * 100 })
+      const response = await (await meilisearch.getIndex(env.MEILISEARCH_PRODUCTS_INDEX!)).getDocuments<CommerceProduct>({ limit: 100, offset: page * 100 })
       allHits.push(...response.results)
       page++
 

--- a/apps/web/components/Icons/StarIcon.tsx
+++ b/apps/web/components/Icons/StarIcon.tsx
@@ -1,0 +1,18 @@
+export const StarIcon = ({ className }: { className?: string }) => {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      className={className}
+    >
+      <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
+    </svg>
+  )
+}

--- a/apps/web/components/Icons/StarIcon.tsx
+++ b/apps/web/components/Icons/StarIcon.tsx
@@ -7,7 +7,7 @@ export const StarIcon = ({ className }: { className?: string }) => {
       viewBox="0 0 24 24"
       fill="none"
       stroke="currentColor"
-      stroke-width="2"
+      strokeWidth="2"
       stroke-linecap="round"
       stroke-linejoin="round"
       className={className}

--- a/apps/web/components/Icons/StarIcon.tsx
+++ b/apps/web/components/Icons/StarIcon.tsx
@@ -8,8 +8,8 @@ export const StarIcon = ({ className }: { className?: string }) => {
       fill="none"
       stroke="currentColor"
       strokeWidth="2"
-      stroke-linecap="round"
-      stroke-linejoin="round"
+      strokeLinecap="round"
+      strokeLinejoin="round"
       className={className}
     >
       <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />

--- a/apps/web/components/Modals/ReviewModal.tsx
+++ b/apps/web/components/Modals/ReviewModal.tsx
@@ -17,6 +17,7 @@ import { Textarea } from "components/Textarea/Textarea"
 import { cn } from "utils/cn"
 
 import { submitReview } from "app/actions/reviews.actions"
+import { StarIcon } from "components/Icons/StarIcon"
 
 const formSchema = z.object({
   email: z.string().email({ message: "Provide email address" }).min(3).max(64),
@@ -178,23 +179,5 @@ function StarList({ name, rating, setRating, ...rest }) {
         ))}
       </fieldset>
     </div>
-  )
-}
-function StarIcon(props: React.SVGProps<SVGSVGElement>) {
-  return (
-    <svg
-      {...props}
-      xmlns="http://www.w3.org/2000/svg"
-      width="24"
-      height="24"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
-      <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
-    </svg>
   )
 }

--- a/apps/web/components/ProductCard/ProductCard.tsx
+++ b/apps/web/components/ProductCard/ProductCard.tsx
@@ -4,7 +4,7 @@ import { cn } from "utils/cn"
 import { QuickAdd } from "./QuickAdd"
 import { type CurrencyType, mapCurrencyToSign } from "utils/mapCurrencyToSign"
 import type { CommerceProduct } from "types"
-import { StarRating } from "views/Product/StarRating"
+import { StarIcon } from "components/Icons/StarIcon"
 
 interface ProductCardProps extends Pick<CommerceProduct, "variants" | "handle" | "images" | "title" | "featuredImage" | "minPrice" | "avgRating" | "totalReviews"> {
   priority?: boolean
@@ -38,9 +38,10 @@ export function ProductCard(props: ProductCardProps) {
           <div className="line-clamp-2 text-base tracking-tight md:text-xl">{props.title}</div>
           {!!props.avgRating && !!props.totalReviews && (
             <div className="flex items-center space-x-1">
-              <StarRating rating={Math.ceil(props.avgRating)} />
-              <span>
-                <span className="text-sm">({props.totalReviews})</span>
+              <StarIcon className="size-4 fill-yellow-400 stroke-yellow-500" />
+              <span className="text-sm">{props.avgRating.toFixed(2)}</span>
+              <span className="text-xs">
+                ({props.totalReviews} review{props.totalReviews !== 1 && "s"})
               </span>
             </div>
           )}

--- a/apps/web/components/ProductCard/ProductCard.tsx
+++ b/apps/web/components/ProductCard/ProductCard.tsx
@@ -1,11 +1,11 @@
-import type { PlatformProduct } from "@enterprise-commerce/core/platform/types"
 import Image from "next/image"
 import Link from "next/link"
 import { cn } from "utils/cn"
 import { QuickAdd } from "./QuickAdd"
 import { type CurrencyType, mapCurrencyToSign } from "utils/mapCurrencyToSign"
+import type { CommerceProduct } from "types"
 
-interface ProductCardProps extends Pick<PlatformProduct, "variants" | "handle" | "images" | "title" | "featuredImage" | "minPrice"> {
+interface ProductCardProps extends Pick<CommerceProduct, "variants" | "handle" | "images" | "title" | "featuredImage" | "minPrice"> {
   priority?: boolean
   className?: string
 }
@@ -30,7 +30,7 @@ export function ProductCard(props: ProductCardProps) {
           />
         </Link>
 
-        <QuickAdd product={props as PlatformProduct} variants={props.variants} />
+        <QuickAdd product={props as CommerceProduct} variants={props.variants} />
       </div>
       <Link aria-label={linkAria} href={href}>
         <div className="mt-4 flex flex-col gap-0.5 text-slate-700">

--- a/apps/web/components/ProductCard/ProductCard.tsx
+++ b/apps/web/components/ProductCard/ProductCard.tsx
@@ -4,8 +4,9 @@ import { cn } from "utils/cn"
 import { QuickAdd } from "./QuickAdd"
 import { type CurrencyType, mapCurrencyToSign } from "utils/mapCurrencyToSign"
 import type { CommerceProduct } from "types"
+import { StarRating } from "views/Product/StarRating"
 
-interface ProductCardProps extends Pick<CommerceProduct, "variants" | "handle" | "images" | "title" | "featuredImage" | "minPrice"> {
+interface ProductCardProps extends Pick<CommerceProduct, "variants" | "handle" | "images" | "title" | "featuredImage" | "minPrice" | "avgRating" | "totalReviews"> {
   priority?: boolean
   className?: string
 }
@@ -35,7 +36,15 @@ export function ProductCard(props: ProductCardProps) {
       <Link aria-label={linkAria} href={href}>
         <div className="mt-4 flex flex-col gap-0.5 text-slate-700">
           <div className="line-clamp-2 text-base tracking-tight md:text-xl">{props.title}</div>
-          {!!variant && !!props.minPrice && (
+          {!!props.avgRating && !!props.totalReviews && (
+            <div className="flex items-center space-x-1">
+              <StarRating rating={Math.ceil(props.avgRating)} />
+              <span>
+                <span className="text-sm">({props.totalReviews})</span>
+              </span>
+            </div>
+          )}
+          {!!variant && (
             <p className="text-base font-semibold tracking-tight text-black md:text-lg">
               From {props.minPrice.toFixed(2) + mapCurrencyToSign(variant.currencyCode as CurrencyType)}
             </p>

--- a/apps/web/components/ProductCard/QuickAdd.tsx
+++ b/apps/web/components/ProductCard/QuickAdd.tsx
@@ -1,9 +1,10 @@
-import type { PlatformProduct, PlatformVariant } from "@enterprise-commerce/core/platform/types"
+import type { PlatformVariant } from "@enterprise-commerce/core/platform/types"
 import { getAllCombinations } from "utils/productOptionsUtils"
 import QuickAddButton from "./QuickAddButton"
+import { CommerceProduct } from "types"
 
 interface QuickAddProps {
-  product: PlatformProduct
+  product: CommerceProduct
   variants: PlatformVariant[]
 }
 

--- a/apps/web/components/ProductCard/QuickAddButton.tsx
+++ b/apps/web/components/ProductCard/QuickAddButton.tsx
@@ -8,10 +8,10 @@ import { cn } from "utils/cn"
 import { Combination } from "utils/productOptionsUtils"
 import { toast } from "sonner"
 import { type CurrencyType, mapCurrencyToSign } from "utils/mapCurrencyToSign"
-import type { PlatformProduct } from "@enterprise-commerce/core/platform/types"
+import type { CommerceProduct } from "types"
 
 interface QuickAddButtonProps {
-  product: PlatformProduct
+  product: CommerceProduct
   combination: Combination | undefined
   label?: string
   className?: string

--- a/apps/web/constants/index.ts
+++ b/apps/web/constants/index.ts
@@ -11,4 +11,4 @@ export const BUCKETS = {
   HOME: ["a", "b"],
 } as const
 
-export const facetParams = ["q", "minPrice", "maxPrice", "sortBy", "categories", "vendors", "tags", "colors", "sizes"]
+export const facetParams = ["q", "minPrice", "maxPrice", "sortBy", "categories", "vendors", "tags", "colors", "sizes", "rating"]

--- a/apps/web/env.mjs
+++ b/apps/web/env.mjs
@@ -13,6 +13,7 @@ export const env = createEnv({
     MEILISEARCH_PRODUCTS_INDEX: z.string(),
     MEILISEARCH_CATEGORIES_INDEX: z.string(),
     MEILISEARCH_REVIEWS_INDEX: z.string().optional(),
+    MEILISEARCH_PRODUCTS_INDEX: z.string().optional(),
     REPLICATE_API_KEY: z.string().optional(),
     LIVE_URL: z.string().optional(),
     GTM_ID: z.string().optional().default(),

--- a/apps/web/scripts/update-products-index.ts
+++ b/apps/web/scripts/update-products-index.ts
@@ -6,7 +6,7 @@ import { env } from "env.mjs"
  * (bulk operation, should be done just once)
  */
 export async function updateProductIndex() {
-  const index = await getMeilisearchIndex(env.MEILISEARCH_PRODUCTS_INDEX)
+  const index = await getMeilisearchIndex(env.MEILISEARCH_PRODUCTS_INDEX!)
 
   const temp_products = await meilisearch.getIndex("temp_products")
 

--- a/apps/web/stores/addProductStore.ts
+++ b/apps/web/stores/addProductStore.ts
@@ -1,11 +1,12 @@
-import type { PlatformProduct, PlatformVariant } from "@enterprise-commerce/core/platform/types"
+import type { PlatformVariant } from "@enterprise-commerce/core/platform/types"
+import type { CommerceProduct } from "types"
 import type { Combination } from "utils/productOptionsUtils"
 import { create } from "zustand"
 
 interface AddProductStore {
-  product: PlatformProduct | null
+  product: CommerceProduct | null
   combination: Combination | null
-  setProduct: ({ product, combination }: { product: PlatformProduct; combination: Combination | PlatformVariant }) => void
+  setProduct: ({ product, combination }: { product: CommerceProduct; combination: Combination | PlatformVariant }) => void
   clean: () => void
 }
 

--- a/apps/web/types/index.ts
+++ b/apps/web/types/index.ts
@@ -1,1 +1,11 @@
+import { PlatformProduct } from "@enterprise-commerce/core/platform/types"
+
 export type SearchParamsType = Record<string, string | string[] | undefined>
+
+/*
+ * Storefront product enriched with the reviews fields that we attach whenever we sync results in meilisearch.
+ */
+export type CommerceProduct = PlatformProduct & {
+  avgRating: number
+  totalReviews: number
+}

--- a/apps/web/types/index.ts
+++ b/apps/web/types/index.ts
@@ -2,9 +2,6 @@ import { PlatformProduct } from "@enterprise-commerce/core/platform/types"
 
 export type SearchParamsType = Record<string, string | string[] | undefined>
 
-/*
- * Storefront product enriched with the reviews fields that we attach whenever we sync results in meilisearch.
- */
 export type CommerceProduct = PlatformProduct & {
   avgRating: number
   totalReviews: number

--- a/apps/web/utils/demoUtils.ts
+++ b/apps/web/utils/demoUtils.ts
@@ -1,10 +1,9 @@
-import { PlatformProduct } from "@enterprise-commerce/core/platform/types"
-import { env } from "env.mjs"
+import type { CommerceProduct } from "types"
 
 export function getDemoProducts() {
   if (!isDemoMode()) return { hits: [], totalPages: 0, facetDistribution: {}, totalHits: 0 }
 
-  const allProducts = require("public/demo-data.json") as { results: PlatformProduct[]; offset: number; limit: number; total: number }
+  const allProducts = require("public/demo-data.json") as { results: CommerceProduct[]; offset: number; limit: number; total: number }
 
   return {
     hits: allProducts.results,

--- a/apps/web/utils/productOptionsUtils.ts
+++ b/apps/web/utils/productOptionsUtils.ts
@@ -1,4 +1,5 @@
-import { PlatformProduct, PlatformVariant } from "@enterprise-commerce/core/platform/types"
+import { PlatformVariant } from "@enterprise-commerce/core/platform/types"
+import type { CommerceProduct } from "types"
 
 export interface Combination {
   id: string
@@ -23,7 +24,7 @@ export function getAllCombinations(variants: PlatformVariant[]): Combination[] {
   }))
 }
 
-export function getCombination(product: PlatformProduct, color: string | null, size: string | null) {
+export function getCombination(product: CommerceProduct, color: string | null, size: string | null) {
   const hasOnlyOneVariant = product.variants.length <= 1
 
   const defaultColor = product.flatOptions?.["Color"]?.find(Boolean)?.toLowerCase() ?? undefined

--- a/apps/web/utils/useAutocomplete.ts
+++ b/apps/web/utils/useAutocomplete.ts
@@ -2,9 +2,8 @@ import { type ChangeEvent, useEffect, useState, useTransition } from "react"
 
 import { useDebounce } from "@uidotdev/usehooks"
 
-import { type PlatformProduct } from "@enterprise-commerce/core/platform/types"
-
 import { searchProducts } from "app/actions/product.actions"
+import type { CommerceProduct } from "types"
 
 /*
  * Callback is optional to be called every time the query changes
@@ -19,7 +18,7 @@ export function useAutocomplete({ callback, debounce = 300, noOfResults = 4 }: A
   const [query, setQuery] = useState("")
   const [hasMore, setHasMore] = useState(false)
   const [status, setStatus] = useState<"idle" | "error" | "loading" | "done">("idle")
-  const [results, setResults] = useState<PlatformProduct[] | null>(null)
+  const [results, setResults] = useState<CommerceProduct[] | null>(null)
 
   const [isPending, startTransition] = useTransition()
   const debouncedQuery = useDebounce(query, debounce)

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -4,6 +4,10 @@
     {
       "path": "/api/reviews/sync",
       "schedule": "30 2 * * *"
+    },
+    {
+      "path": "/api/reviews/sync-products",
+      "schedule": "30 2 * * *"
     }
   ]
 }

--- a/apps/web/views/Homepage/BestOffersSection.tsx
+++ b/apps/web/views/Homepage/BestOffersSection.tsx
@@ -1,9 +1,9 @@
-import { PlatformProduct } from "@enterprise-commerce/core/platform/types"
 import { meilisearch } from "clients/meilisearch"
 import { unstable_cache } from "next/cache"
 import { CarouselSection } from "./CarouselSection"
 import { getDemoProducts, isDemoMode } from "utils/demoUtils"
 import { env } from "env.mjs"
+import type { CommerceProduct } from "types"
 
 export async function BestOffersSection() {
   const items = await getBestOffers()
@@ -15,7 +15,7 @@ const getBestOffers = unstable_cache(
   async () => {
     if (isDemoMode()) return getDemoProducts().hits.slice(0, 8)
 
-    const index = await meilisearch?.getIndex<PlatformProduct>(env.MEILISEARCH_PRODUCTS_INDEX)
+    const index = await meilisearch?.getIndex<CommerceProduct>(env.MEILISEARCH_PRODUCTS_INDEX!)
     const results = await index.search("", { matchingStrategy: "last", limit: 8, sort: ["minPrice:asc"] })
 
     return [...results.hits]

--- a/apps/web/views/Homepage/BestOffersSection.tsx
+++ b/apps/web/views/Homepage/BestOffersSection.tsx
@@ -8,8 +8,6 @@ import type { CommerceProduct } from "types"
 export async function BestOffersSection() {
   const items = await getBestOffers()
 
-  console.log({ items })
-
   return <CarouselSection title="Best Offers" items={items} />
 }
 

--- a/apps/web/views/Homepage/BestOffersSection.tsx
+++ b/apps/web/views/Homepage/BestOffersSection.tsx
@@ -8,6 +8,8 @@ import type { CommerceProduct } from "types"
 export async function BestOffersSection() {
   const items = await getBestOffers()
 
+  console.log({ items })
+
   return <CarouselSection title="Best Offers" items={items} />
 }
 

--- a/apps/web/views/Homepage/CarouselSection.tsx
+++ b/apps/web/views/Homepage/CarouselSection.tsx
@@ -1,11 +1,11 @@
-import { PlatformProduct } from "@enterprise-commerce/core/platform/types"
 import { Carousel, CarouselContent, CarouselNext, CarouselPrevious } from "components/Carousel/Carousel"
 import { ProductCard } from "components/ProductCard/ProductCard"
 import { Skeleton } from "components/Skeleton/Skeleton"
+import type { CommerceProduct } from "types"
 
 interface CarouselSectionProps {
   title: string
-  items: PlatformProduct[]
+  items: CommerceProduct[]
 }
 
 export function CarouselSection({ items, title }: CarouselSectionProps) {

--- a/apps/web/views/Homepage/EverythingUnderSection.tsx
+++ b/apps/web/views/Homepage/EverythingUnderSection.tsx
@@ -1,10 +1,10 @@
-import { PlatformProduct } from "@enterprise-commerce/core/platform/types"
 import { meilisearch } from "clients/meilisearch"
 import { unstable_cache } from "next/cache"
 import { ComparisonOperators, FilterBuilder } from "utils/filterBuilder"
 import { CarouselSection } from "./CarouselSection"
 import { getDemoProducts, isDemoMode } from "utils/demoUtils"
 import { env } from "env.mjs"
+import type { CommerceProduct } from "types"
 
 export async function EverythingUnderSection() {
   const items = await getPriceRangedProducts()
@@ -16,7 +16,7 @@ const getPriceRangedProducts = unstable_cache(
   async () => {
     if (isDemoMode()) return getDemoProducts().hits.slice(0, 8)
 
-    const index = await meilisearch?.getIndex<PlatformProduct>(env.MEILISEARCH_PRODUCTS_INDEX)
+    const index = await meilisearch?.getIndex<CommerceProduct>(env.MEILISEARCH_PRODUCTS_INDEX!)
     const results = await index.search("", {
       matchingStrategy: "last",
       limit: 8,

--- a/apps/web/views/Homepage/ProductsWeekSection.tsx
+++ b/apps/web/views/Homepage/ProductsWeekSection.tsx
@@ -1,4 +1,3 @@
-import { PlatformProduct } from "@enterprise-commerce/core/platform/types"
 import { meilisearch } from "clients/meilisearch"
 import { Carousel, CarouselContent } from "components/Carousel/Carousel"
 import { Skeleton } from "components/Skeleton/Skeleton"
@@ -7,6 +6,7 @@ import { unstable_cache } from "next/cache"
 import Image from "next/image"
 import Link from "next/link"
 import { getDemoProducts, isDemoMode } from "utils/demoUtils"
+import type { CommerceProduct } from "types"
 
 export async function ProductsWeekSection() {
   const items = await getNewestProducts()
@@ -46,7 +46,7 @@ const getNewestProducts = unstable_cache(
   async () => {
     if (isDemoMode()) return getDemoProducts().hits.slice(0, 8)
 
-    const index = await meilisearch?.getIndex<PlatformProduct>(env.MEILISEARCH_PRODUCTS_INDEX)
+    const index = await meilisearch?.getIndex<CommerceProduct>(env.MEILISEARCH_PRODUCTS_INDEX!)
     const results = await index.search("", { matchingStrategy: "last", limit: 8, sort: ["updatedAtTimestamp:desc"] })
 
     return [...results.hits]

--- a/apps/web/views/Listing/HitsSection.tsx
+++ b/apps/web/views/Listing/HitsSection.tsx
@@ -1,8 +1,8 @@
-import { PlatformProduct } from "@enterprise-commerce/core/platform/types"
 import { ProductCard } from "components/ProductCard/ProductCard"
+import type { CommerceProduct } from "types"
 
 interface HitsSectionProps {
-  hits: PlatformProduct[]
+  hits: CommerceProduct[]
 }
 
 export async function HitsSection({ hits }: HitsSectionProps) {

--- a/apps/web/views/Listing/RatingFacet.tsx
+++ b/apps/web/views/Listing/RatingFacet.tsx
@@ -1,0 +1,38 @@
+import { AccordionContent, AccordionItem, AccordionTrigger } from "components/Accordion/Accordion"
+import { Checkbox } from "components/Checkbox/Checkbox"
+import { Label } from "components/Label/Label"
+import { StarRating } from "views/Product/StarRating"
+
+interface FacetProps {
+  id: string
+  title: string
+  distribution: Record<string, number> | undefined
+  isChecked: (value: string) => boolean
+  onCheckedChange: (checked: boolean, value: string) => void
+}
+
+export function RatingFacet({ id, title, distribution, isChecked, onCheckedChange }: FacetProps) {
+  const distributionsEntries = Object.entries(distribution || {})
+
+  const hasNoResults = distributionsEntries.length === 0
+
+  return (
+    <AccordionItem value={id}>
+      <AccordionTrigger className="text-base">{title}</AccordionTrigger>
+      <AccordionContent>
+        {hasNoResults ? (
+          <p className="text-[14px] text-neutral-500">No {title.toLowerCase()} found</p>
+        ) : (
+          <div className="grid gap-2">
+            {distributionsEntries.map(([value, noOfItems], index) => (
+              <Label key={value + index} className="flex items-center gap-2 font-normal">
+                <Checkbox name={value} checked={isChecked(value)} onCheckedChange={(checked) => onCheckedChange(!!checked, value)} />
+                <StarRating rating={parseInt(value)} /> {parseInt(value) !== 5 && `& up`} ({noOfItems} item{noOfItems !== 1 && "s"})
+              </Label>
+            ))}
+          </div>
+        )}
+      </AccordionContent>
+    </AccordionItem>
+  )
+}

--- a/apps/web/views/Listing/Sorter.tsx
+++ b/apps/web/views/Listing/Sorter.tsx
@@ -10,11 +10,13 @@ export enum Sorting {
   DATE_ASC = "updatedAtTimestamp:asc",
   DATE_DESC = "updatedAtTimestamp:desc",
   RELEVANCY = "",
+  RATING = "avgRating:desc",
 }
 
 const LABELS = {
   [Sorting.PRICE_DESC]: "Price: High to Low",
   [Sorting.PRICE_ASC]: "Price: Low to High",
+  [Sorting.RATING]: "Customer Reviews",
   [Sorting.DATE_ASC]: "Newest",
   [Sorting.DATE_DESC]: "Oldest",
   [Sorting.RELEVANCY]: "Relevancy",

--- a/apps/web/views/Listing/composeFilters.ts
+++ b/apps/web/views/Listing/composeFilters.ts
@@ -8,6 +8,7 @@ interface MakeFilterProps {
   tags: string[]
   colors: string[]
   sizes: string[]
+  rating: number | null
 }
 
 export function composeFilters(filter: FilterBuilder, parsedSearchParams: MakeFilterProps) {
@@ -39,6 +40,10 @@ export function composeFilters(filter: FilterBuilder, parsedSearchParams: MakeFi
     {
       predicate: !!parsedSearchParams.maxPrice,
       action: () => filter.and().where("minPrice", ComparisonOperators.LessThanOrEqual, parsedSearchParams.maxPrice!),
+    },
+    {
+      predicate: !!parsedSearchParams.rating,
+      action: () => filter.and().where("avgRating", ComparisonOperators.GreaterThanOrEqual, parsedSearchParams.rating!),
     },
   ]
 

--- a/apps/web/views/Product/AddToCartButton.tsx
+++ b/apps/web/views/Product/AddToCartButton.tsx
@@ -1,4 +1,4 @@
-import type { PlatformProduct, PlatformVariant } from "@enterprise-commerce/core/platform/types"
+import type { PlatformVariant } from "@enterprise-commerce/core/platform/types"
 import { addCartItem, getItemAvailability } from "app/actions/cart.actions"
 import { Button } from "components/Button/Button"
 import { useEffect, useState } from "react"
@@ -9,6 +9,7 @@ import { COOKIE_CART_ID } from "constants/index"
 import { useAddProductStore } from "stores/addProductStore"
 import { toast } from "sonner"
 import { useCartStore } from "stores/cartStore"
+import type { CommerceProduct } from "types"
 
 export function AddToCartButton({
   className,
@@ -16,7 +17,7 @@ export function AddToCartButton({
   combination,
 }: {
   className?: string
-  product: PlatformProduct
+  product: CommerceProduct
   combination: Combination | PlatformVariant | undefined
   slug: string
 }) {

--- a/apps/web/views/Product/DetailsSection.tsx
+++ b/apps/web/views/Product/DetailsSection.tsx
@@ -1,16 +1,16 @@
 "use client"
 
-import { PlatformProduct } from "@enterprise-commerce/core/platform/types"
 import { useIntersectionObserver } from "@uidotdev/usehooks"
 import dynamic from "next/dynamic"
 import { getCombination, getOptionsFromUrl } from "utils/productOptionsUtils"
 import { AddToCartButtonSkeleton, FaqSectionSkeleton } from "./PageSkeleton"
 import { useRef } from "react"
+import type { CommerceProduct } from "types"
 
 const AddToCartButton = dynamic(() => import("views/Product/AddToCartButton").then((module) => module.AddToCartButton), { loading: AddToCartButtonSkeleton })
 const FaqSection = dynamic(() => import("views/Product/FaqSection").then((module) => module.FaqSection), { loading: FaqSectionSkeleton })
 
-export function DetailsSection({ product, slug }: { product: PlatformProduct; slug: string }) {
+export function DetailsSection({ product, slug }: { product: CommerceProduct; slug: string }) {
   const hasLoaded = useRef(false)
   const [ref, entry] = useIntersectionObserver({
     threshold: 0,

--- a/apps/web/views/Product/InfoSection.tsx
+++ b/apps/web/views/Product/InfoSection.tsx
@@ -1,17 +1,31 @@
 import { PlatformVariant } from "@enterprise-commerce/core/platform/types"
+import { StarIcon } from "components/Icons/StarIcon"
 import { Combination } from "utils/productOptionsUtils"
+import { StarRating } from "./StarRating"
 
 interface InfoSectionProps {
   title: string
   description: string
   combination: Combination | PlatformVariant | undefined
   className?: string
+  avgRating: number
+  totalReviews: number
 }
 
-export function InfoSection({ title, description, combination, className }: InfoSectionProps) {
+export function InfoSection({ title, description, combination, className, avgRating, totalReviews }: InfoSectionProps) {
   return (
     <div className={className}>
-      <h1 className="mb-6 text-xl/6 tracking-[-1px] md:text-4xl">{title}</h1>
+      <div className="mb-6">
+        <h1 className="mb-1 text-xl/6 tracking-[-1px] md:text-4xl">{title}</h1>
+        {!!avgRating && !!totalReviews && (
+          <div className="flex items-center space-x-1">
+            <StarRating rating={Math.ceil(avgRating)} /> {/* rounds up always */}
+            <span className="text-xs text-gray-400">
+              ({avgRating}) based on {totalReviews} review{totalReviews === 1 ? "" : "s"}
+            </span>
+          </div>
+        )}
+      </div>
       {description && <div className="text-[17px] leading-tight tracking-normal text-neutral-500" dangerouslySetInnerHTML={{ __html: description }} />}
       {!!combination?.price && (
         <div className="mt-4 text-[36px] font-bold tracking-[-1.44px]">{parseFloat(combination?.price.amount).toFixed(2) + " " + combination?.price.currencyCode}</div>

--- a/apps/web/views/Product/InfoSection.tsx
+++ b/apps/web/views/Product/InfoSection.tsx
@@ -7,8 +7,8 @@ interface InfoSectionProps {
   description: string
   combination: Combination | PlatformVariant | undefined
   className?: string
-  avgRating: number
-  totalReviews: number
+  avgRating?: number
+  totalReviews?: number
 }
 
 export function InfoSection({ title, description, combination, className, avgRating, totalReviews }: InfoSectionProps) {
@@ -18,7 +18,7 @@ export function InfoSection({ title, description, combination, className, avgRat
         <h1 className="mb-1 text-xl/6 tracking-[-1px] md:text-4xl">{title}</h1>
         {!!avgRating && !!totalReviews && (
           <div className="flex items-center space-x-1">
-            <StarRating rating={Math.ceil(avgRating)} /> {/* rounds up always */}
+            <StarRating rating={Math.ceil(avgRating)} />
             <span className="text-xs text-gray-400">
               ({avgRating}) based on {totalReviews} review{totalReviews !== 1 && "s"}
             </span>

--- a/apps/web/views/Product/InfoSection.tsx
+++ b/apps/web/views/Product/InfoSection.tsx
@@ -1,5 +1,4 @@
 import { PlatformVariant } from "@enterprise-commerce/core/platform/types"
-import { StarIcon } from "components/Icons/StarIcon"
 import { Combination } from "utils/productOptionsUtils"
 import { StarRating } from "./StarRating"
 
@@ -21,7 +20,7 @@ export function InfoSection({ title, description, combination, className, avgRat
           <div className="flex items-center space-x-1">
             <StarRating rating={Math.ceil(avgRating)} /> {/* rounds up always */}
             <span className="text-xs text-gray-400">
-              ({avgRating}) based on {totalReviews} review{totalReviews === 1 ? "" : "s"}
+              ({avgRating}) based on {totalReviews} review{totalReviews !== 1 && "s"}
             </span>
           </div>
         )}

--- a/apps/web/views/Product/SimilarProductsSection.tsx
+++ b/apps/web/views/Product/SimilarProductsSection.tsx
@@ -1,4 +1,3 @@
-import { PlatformProduct } from "@enterprise-commerce/core/platform/types"
 import { meilisearch } from "clients/meilisearch"
 import { Carousel, CarouselContent } from "components/Carousel/Carousel"
 import { ProductCard } from "components/ProductCard/ProductCard"
@@ -6,6 +5,7 @@ import { unstable_cache } from "next/cache"
 import { ComparisonOperators, FilterBuilder } from "utils/filterBuilder"
 import { getDemoProducts, isDemoMode } from "utils/demoUtils"
 import { env } from "env.mjs"
+import type { CommerceProduct } from "types"
 
 interface SimilarProductsSectionProps {
   slug: string
@@ -35,7 +35,7 @@ const getSimilarProducts = unstable_cache(
 
     if (isDemoMode()) return getDemoProducts().hits.slice(0, limit)
 
-    const index = await meilisearch?.getIndex<PlatformProduct>(env.MEILISEARCH_PRODUCTS_INDEX)
+    const index = await meilisearch?.getIndex<CommerceProduct>(env.MEILISEARCH_PRODUCTS_INDEX!)
     const similarSearchResults = await index.search(handle, { matchingStrategy: "last", limit, hybrid: { semanticRatio: 1 } })
 
     let collectionSearchResults = { hits: [] }

--- a/apps/web/views/Product/StarRating.tsx
+++ b/apps/web/views/Product/StarRating.tsx
@@ -1,3 +1,4 @@
+import { StarIcon } from "components/Icons/StarIcon"
 import { cn } from "utils/cn"
 
 export const StarRating = ({ rating }: { rating: number }) => {
@@ -9,24 +10,5 @@ export const StarRating = ({ rating }: { rating: number }) => {
         <StarIcon key={star} className={cn("size-4", star <= rating ? "fill-yellow-400 stroke-yellow-500" : "stroke-yellow-500")} />
       ))}
     </div>
-  )
-}
-
-function StarIcon(props: React.SVGProps<SVGSVGElement>) {
-  return (
-    <svg
-      {...props}
-      xmlns="http://www.w3.org/2000/svg"
-      width="24"
-      height="24"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
-      <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
-    </svg>
   )
 }

--- a/apps/web/views/Search/SearchView.tsx
+++ b/apps/web/views/Search/SearchView.tsx
@@ -1,5 +1,5 @@
 import { type ReactNode, Suspense } from "react"
-import { PlatformCollection, PlatformProduct } from "@enterprise-commerce/core/platform/types"
+import type { PlatformCollection } from "@enterprise-commerce/core/platform/types"
 import { unstable_cache } from "next/cache"
 import { createSearchParamsCache, parseAsArrayOf, parseAsInteger, parseAsString } from "nuqs/server"
 import { meilisearch } from "clients/meilisearch"
@@ -13,8 +13,8 @@ import { PaginationSection } from "views/Listing/PaginationSection"
 import { SearchFacet } from "views/Listing/SearchFacet"
 import { Sorter } from "views/Listing/Sorter"
 import { getDemoProducts, isDemoMode } from "utils/demoUtils"
-import { SearchParamsType } from "types"
 import { env } from "env.mjs"
+import { CommerceProduct, SearchParamsType } from "types"
 
 interface SearchViewProps {
   searchParams: SearchParamsType
@@ -83,7 +83,7 @@ const searchProducts = unstable_cache(
   async (query: string, sortBy: string, page: number, filter: string) => {
     if (isDemoMode()) return getDemoProducts()
 
-    const index = await meilisearch?.getIndex<PlatformProduct>(env.MEILISEARCH_PRODUCTS_INDEX)
+    const index = await meilisearch?.getIndex<CommerceProduct>(env.MEILISEARCH_PRODUCTS_INDEX!)
 
     const results = await index?.search(query, {
       sort: sortBy ? [sortBy] : undefined,
@@ -91,7 +91,7 @@ const searchProducts = unstable_cache(
       facets: ["collections.handle", "tags", "vendor", "variants.availableForSale", "flatOptions.Size", "flatOptions.Color", "minPrice"],
       filter,
       page,
-      attributesToRetrieve: ["id", "handle", "title", "priceRange", "featuredImage", "minPrice", "variants", "images"],
+      attributesToRetrieve: ["id", "handle", "title", "priceRange", "featuredImage", "minPrice", "variants", "images", "avgRating", "totalReviews"],
     })
 
     const hits = results?.hits || []

--- a/apps/web/views/Search/SearchView.tsx
+++ b/apps/web/views/Search/SearchView.tsx
@@ -35,6 +35,7 @@ export const searchParamsCache = createSearchParamsCache({
   tags: parseAsArrayOf(parseAsString).withDefault([]),
   colors: parseAsArrayOf(parseAsString).withDefault([]),
   sizes: parseAsArrayOf(parseAsString).withDefault([]),
+  rating: parseAsInteger,
 })
 
 export async function SearchView({ searchParams, disabledFacets, intro, collection }: SearchViewProps) {
@@ -88,7 +89,7 @@ const searchProducts = unstable_cache(
     const results = await index?.search(query, {
       sort: sortBy ? [sortBy] : undefined,
       hitsPerPage: 24,
-      facets: ["collections.handle", "tags", "vendor", "variants.availableForSale", "flatOptions.Size", "flatOptions.Color", "minPrice"],
+      facets: ["collections.handle", "collections.title", "tags", "vendor", "variants.availableForSale", "flatOptions.Size", "flatOptions.Color", "minPrice", "avgRating"],
       filter,
       page,
       attributesToRetrieve: ["id", "handle", "title", "priceRange", "featuredImage", "minPrice", "variants", "images", "avgRating", "totalReviews"],


### PR DESCRIPTION
- Refactor  types in web to use local type `CommerceProduct` instead of `PlatformProduct` - its enriched by the reviews data now
- Adds cron job to run (daily) to sync products index with. avgRating and totalReviews
- Adds API route for the above
-  Adds UI to display avg Rating and total reviews on product cards and PDP itself
- Adds logic & routing for faceting
