### PR TITLE
fix(commerce): memory issue when bundler fails

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "prebuild": "rm -rf .turbo && rm -rf node_modules && rm -rf dist",
     "build": "cross-env FORCE_COLOR=1 tsup **/*.ts --format esm,cjs --dts --external react",
-    "dev": "cross-env FORCE_COLOR=1 tsup **/*.ts --format esm,cjs --watch --dts --external react --onSuccess 'node dist/index.mjs about'",
+    "dev": "yarn clean && cross-env FORCE_COLOR=1 tsup **/*.ts --format esm,cjs --watch --dts --external react --onSuccess 'node dist/index.mjs about'",
     "lint": "cross-env FORCE_COLOR=1 eslint .",
     "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist",
     "test": "cross-env FORCE_COLOR=1 jest --passWithNoTests",


### PR DESCRIPTION
As reported, some people may encounter `heap out of memory` issues, which may be caused by a compiler bug. This bug occurs when `d.ts` points to an old hash, causing the first build to fail and subsequent builds to enter an infinite loop after code changes.

Cleaning always before bundling should fix it